### PR TITLE
Add support for v09 of MoQT

### DIFF
--- a/examples/moq-sub.c
+++ b/examples/moq-sub.c
@@ -167,7 +167,7 @@ static void imquic_demo_incoming_object(imquic_connection *conn, imquic_moq_obje
 		return;
 	}
 	if(object->extensions != NULL && object->extensions_len > 0) {
-		GList *extensions = imquic_moq_parse_object_extensions(object->extensions_count, object->extensions, object->extensions_len);
+		GList *extensions = imquic_moq_parse_object_extensions(object->extensions, object->extensions_len);
 		GList *temp = extensions;
 		while(temp) {
 			imquic_moq_object_extension *ext = (imquic_moq_object_extension *)temp->data;

--- a/src/imquic-moq.c
+++ b/src/imquic-moq.c
@@ -488,6 +488,8 @@ const char *imquic_moq_version_str(imquic_moq_version version) {
 			return "draft-ietf-moq-transport-07";
 		case IMQUIC_MOQ_VERSION_08:
 			return "draft-ietf-moq-transport-08";
+		case IMQUIC_MOQ_VERSION_09:
+			return "draft-ietf-moq-transport-09";
 		case IMQUIC_MOQ_VERSION_ANY:
 			return "draft-ietf-moq-transport-XX";
 		case IMQUIC_MOQ_VERSION_ANY_LEGACY:

--- a/src/imquic/moq.h
+++ b/src/imquic/moq.h
@@ -146,7 +146,7 @@
  * called \c IMQUIC_MOQ_VERSION_ANY_LEGACY is available, to negotiate any supported
  * version that is lower than v06. At the time of writing, this stack
  * supports MoQ versions from v03 ( \c IMQUIC_MOQ_VERSION_03 ) up to
- * v08 ( \c IMQUIC_MOQ_VERSION_08 ), but not all versions will be supported
+ * v09 ( \c IMQUIC_MOQ_VERSION_09 ), but not all versions will be supported
  * forever. It should also be pointed out that not all features of all
  * versions are currently supported, so there may be some missing functionality
  * depending on which version you decide to negotiate. The \c IMQUIC_MOQ_VERSION_MIN
@@ -439,11 +439,10 @@ typedef struct imquic_moq_object_extension {
 } imquic_moq_object_extension;
 /*! \brief Helper mode to parse an extensions buffer to a GList of imquic_moq_object_extension
  * \note The caller owns the list, and is responsible of freeing it and its content
- * @param count How many extensions are contained in the buffer
  * @param extensions The buffer containing the extensions data
  * @param elen The size of the buffer containing the extensions data
  * @returns A GList instance containing a set of imquic_moq_object_extension, if successful, or NULL if no extensions were found */
-GList *imquic_moq_parse_object_extensions(size_t count, uint8_t *extensions, size_t elen);
+GList *imquic_moq_parse_object_extensions(uint8_t *extensions, size_t elen);
 /*! \brief Helper mode to craft an extensions buffer out of a GList of imquic_moq_object_extension
  * @param[in] extensions The buffer containing the extensions data
  * @param[out] bytes The buffer to write the extensions data to
@@ -480,7 +479,7 @@ typedef struct imquic_moq_object {
 	uint8_t *extensions;
 	/*! \brief Size of the MoQ object extensions (only since v08) */
 	size_t extensions_len;
-	/*! \brief Count of the MoQ object extensions (only since v08) */
+	/*! \brief Count of the MoQ object extensions (only v08, deprecated in v09) */
 	size_t extensions_count;
 	/*! \brief How to send this object (or how it was received) */
 	imquic_moq_delivery delivery;
@@ -767,7 +766,9 @@ typedef enum imquic_moq_version {
 	IMQUIC_MOQ_VERSION_07 = 0xff000007,
 	/* Draft version -08 */
 	IMQUIC_MOQ_VERSION_08 = 0xff000008,
-	IMQUIC_MOQ_VERSION_MAX = IMQUIC_MOQ_VERSION_08,
+	/* Draft version -09 */
+	IMQUIC_MOQ_VERSION_09 = 0xff000009,
+	IMQUIC_MOQ_VERSION_MAX = IMQUIC_MOQ_VERSION_09,
 	/* Any post-v06 version: for client, it means offer all supported versions;
 	 * for servers, it means accept the first supported offered version */
 	IMQUIC_MOQ_VERSION_ANY = 0xffffffff,

--- a/src/internal/moq.h
+++ b/src/internal/moq.h
@@ -1053,7 +1053,7 @@ size_t imquic_moq_add_object_stream(imquic_moq_context *moq, uint8_t *bytes, siz
  * @param priority The publisher priority to put in the message (only after v05)
  * @param payload The buffer containing the payload of the object
  * @param plen The size of the payload buffer
- * @param extensions_count The number of object extensions, if any (only since v08)
+ * @param extensions_count The number of object extensions, if any (only in v08, deprecated in v09)
  * @param extensions The buffer containing the object extensions, if any (only since v08)
  * @param elen The size of the object extensions buffer (only since v08)
  * @returns The size of the generated message, if successful, or 0 otherwise */
@@ -1070,9 +1070,12 @@ size_t imquic_moq_add_object_datagram(imquic_moq_context *moq, uint8_t *bytes, s
  * @param object_id The object ID to put in the message
  * @param priority The publisher priority to put in the message (only after v05)
  * @param object_status The object status (only added if the payload length is 0)
+ * @param extensions The buffer containing the object extensions, if any (only since v09)
+ * @param elen The size of the object extensions buffer (only since v09)
  * @returns The size of the generated message, if successful, or 0 otherwise */
 size_t imquic_moq_add_object_datagram_status(imquic_moq_context *moq, uint8_t *bytes, size_t blen,
-	uint64_t track_alias, uint64_t group_id, uint64_t object_id, uint8_t priority, uint64_t object_status);
+	uint64_t track_alias, uint64_t group_id, uint64_t object_id, uint8_t priority,
+	uint64_t object_status, uint8_t *extensions, size_t elen);
 /*! \brief Helper to add a \c STREAM_HEADER_TRACK message to a buffer (only before v06)
  * @note This will create a new \c STREAM and send the header: after
  * that, imquic_moq_add_stream_header_track_object is used to send
@@ -1151,7 +1154,7 @@ size_t imquic_moq_add_subgroup_header(imquic_moq_context *moq, uint8_t *bytes, s
  * @param object_status The object status (only added if the payload length is 0)
  * @param payload The buffer containing the payload of the object
  * @param plen The size of the payload buffer
- * @param extensions_count The number of object extensions, if any (only since v08)
+ * @param extensions_count The number of object extensions, if any (only in v08, deprecated in v09)
  * @param extensions The buffer containing the object extensions, if any (only since v08)
  * @param elen The size of the object extensions buffer (only since v08)
  * @returns The size of the generated object, if successful, or 0 otherwise */
@@ -1180,7 +1183,7 @@ size_t imquic_moq_add_fetch_header(imquic_moq_context *moq, uint8_t *bytes, size
  * @param object_status The object status (only added if the payload length is 0)
  * @param payload The buffer containing the payload of the object
  * @param plen The size of the payload buffer
- * @param extensions_count The number of object extensions, if any (only since v08)
+ * @param extensions_count The number of object extensions, if any (only in v08, deprecated in v09)
  * @param extensions The buffer containing the object extensions, if any (only since v08)
  * @param elen The size of the object extensions buffer (only since v08)
  * @returns The size of the generated object, if successful, or 0 otherwise */
@@ -1201,7 +1204,7 @@ size_t imquic_moq_add_goaway(imquic_moq_context *moq, uint8_t *bytes, size_t ble
  * @param moq The imquic_moq_context generating the message
  * @param bytes The buffer to add the extensions to
  * @param blen The size of the buffer
- * @param extensions_count The number of object extensions, if any
+ * @param extensions_count The number of object extensions, if any (ignored after v08, since v09 deprecated it)
  * @param extensions The buffer containing the object extensions, if any
  * @param elen The size of the object extensions buffer
  * @returns The size of the generated extensions block, if successful, or 0 otherwise */


### PR DESCRIPTION
Version [09](https://author-tools.ietf.org/iddiff?url2=draft-ietf-moq-transport-09) of the draft is out: the main change from 08 (implemented in #1) is that extensions don't have a count field, but a length field. To still allow for compatiblity with 08, the `extensions_count` property in objects is still there, but is unused in `09`. This PR also adds extensions to `OBJECT_DATAGRAM_STATUS`.