### PR TITLE
Implement QLOG for RoQ

### DIFF
--- a/examples/moq-chat.c
+++ b/examples/moq-chat.c
@@ -441,6 +441,7 @@ int main(int argc, char *argv[]) {
 		IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
 		IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
 		IMQUIC_CONFIG_QLOG_MOQ, qlog_moq,
+		IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
 		IMQUIC_CONFIG_DONE, NULL);
 	if(client == NULL) {
 		ret = 1;

--- a/examples/moq-pub.c
+++ b/examples/moq-pub.c
@@ -336,6 +336,7 @@ int main(int argc, char *argv[]) {
 		IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
 		IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
 		IMQUIC_CONFIG_QLOG_MOQ, qlog_moq,
+		IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
 		IMQUIC_CONFIG_DONE, NULL);
 	if(client == NULL) {
 		ret = 1;

--- a/examples/moq-relay.c
+++ b/examples/moq-relay.c
@@ -1004,6 +1004,7 @@ int main(int argc, char *argv[]) {
 		IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
 		IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
 		IMQUIC_CONFIG_QLOG_MOQ, qlog_moq,
+		IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
 		IMQUIC_CONFIG_DONE, NULL);
 	if(server == NULL) {
 		ret = 1;

--- a/examples/roq-client-options.c
+++ b/examples/roq-client-options.c
@@ -34,6 +34,7 @@ gboolean demo_options_parse(demo_options *options, int argc, char *argv[]) {
 		{ "zero-rtt", '0', 0, G_OPTION_ARG_STRING, &options->ticket_file, "Whether early data via 0-RTT should be supported, and what file to use for writing/reading the session ticket (default=none)", "path" },
 		{ "secrets-log", 's', 0, G_OPTION_ARG_STRING, &options->secrets_log, "Save the exchanged secrets to a file compatible with Wireshark (default=none)", "path" },
 		{ "qlog-path", 'Q', 0, G_OPTION_ARG_STRING, &options->qlog_path, "Save a QLOG file for this connection (default=none)", "path" },
+		{ "qlog-logging", 'l', 0, G_OPTION_ARG_STRING_ARRAY, &options->qlog_logging, "Save these events to QLOG (can be called multiple times to save multiple things; default=none)", "quic|roq" },
 		{ "qlog-sequential", 'J', 0, G_OPTION_ARG_NONE, &options->qlog_sequential, "Whether sequential JSON should be used for the QLOG file, instead of regular JSON (default=no)", NULL },
 		{ "debug-level", 'd', 0, G_OPTION_ARG_INT, &options->debug_level, "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)", "1-7" },
 		{ "debug-locks", 'L', 0, G_OPTION_ARG_NONE, &options->debug_locks, "Whether to verbosely debug mutex/lock accesses (default=no)", NULL },

--- a/examples/roq-client-options.h
+++ b/examples/roq-client-options.h
@@ -34,6 +34,7 @@ typedef struct demo_options {
 	const char *ticket_file;
 	const char *secrets_log;
 	const char *qlog_path;
+	const char **qlog_logging;
 	gboolean qlog_sequential;
 	int debug_level;
 	gboolean debug_locks;

--- a/examples/roq-client.c
+++ b/examples/roq-client.c
@@ -217,11 +217,23 @@ int main(int argc, char *argv[]) {
 	}
 
 	/* Check if we need to create a QLOG file */
+	gboolean qlog_quic = FALSE, qlog_roq = FALSE;
 	if(options.qlog_path != NULL) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "Creating QLOG file '%s'\n", options.qlog_path);
 		if(options.qlog_sequential)
 			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Using sequential JSON\n");
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Logging QUIC events\n");
+		int i = 0;
+		while(options.qlog_logging != NULL && options.qlog_logging[i] != NULL) {
+			if(!strcasecmp(options.qlog_logging[i], "quic")) {
+				IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Logging QUIC events\n");
+				qlog_quic = TRUE;
+			} else if(!strcasecmp(options.qlog_logging[i], "roq")) {
+				IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Logging RoQ events\n");
+				qlog_roq = TRUE;
+			}
+			i++;
+		}
 	}
 
 	/* Initialize the library and create a server */
@@ -245,7 +257,8 @@ int main(int argc, char *argv[]) {
 		IMQUIC_CONFIG_TICKET_FILE, options.ticket_file,
 		IMQUIC_CONFIG_HTTP3_PATH, options.path,
 		IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
-		IMQUIC_CONFIG_QLOG_QUIC, (options.qlog_path != NULL),
+		IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
+		IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
 		IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
 		IMQUIC_CONFIG_DONE, NULL);
 	if(client == NULL) {

--- a/examples/roq-server-options.c
+++ b/examples/roq-server-options.c
@@ -25,6 +25,7 @@ gboolean demo_options_parse(demo_options *options, int argc, char *argv[]) {
 		{ "zero-rtt", '0', 0, G_OPTION_ARG_NONE, &options->early_data, "Whether early data via 0-RTT should be supported (default=no)", NULL },
 		{ "secrets-log", 's', 0, G_OPTION_ARG_STRING, &options->secrets_log, "Save the exchanged secrets to a file compatible with Wireshark (default=none)", "path" },
 		{ "qlog-path", 'Q', 0, G_OPTION_ARG_STRING, &options->qlog_path, "Path to a folder where to save QLOG files for all connections (default=none)", "path" },
+		{ "qlog-logging", 'l', 0, G_OPTION_ARG_STRING_ARRAY, &options->qlog_logging, "Save these events to QLOG (can be called multiple times to save multiple things; default=none)", "quic|roq" },
 		{ "qlog-sequential", 'J', 0, G_OPTION_ARG_NONE, &options->qlog_sequential, "Whether sequential JSON should be used for the QLOG file, instead of regular JSON (default=no)", NULL },
 		{ "debug-level", 'd', 0, G_OPTION_ARG_INT, &options->debug_level, "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)", "1-7" },
 		{ "debug-locks", 'L', 0, G_OPTION_ARG_NONE, &options->debug_locks, "Whether to verbosely debug mutex/lock accesses (default=no)", NULL },

--- a/examples/roq-server-options.h
+++ b/examples/roq-server-options.h
@@ -25,6 +25,7 @@ typedef struct demo_options {
 	gboolean early_data;
 	const char *secrets_log;
 	const char *qlog_path;
+	const char **qlog_logging;
 	gboolean qlog_sequential;
 	int debug_level;
 	gboolean debug_locks;

--- a/examples/roq-server.c
+++ b/examples/roq-server.c
@@ -151,11 +151,23 @@ int main(int argc, char *argv[]) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "Early data support enabled\n");
 
 	/* Check if we need to create a QLOG file */
+	gboolean qlog_quic = FALSE, qlog_roq = FALSE;
 	if(options.qlog_path != NULL) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "Creating QLOG file(s) in '%s'\n", options.qlog_path);
 		if(options.qlog_sequential)
 			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Using sequential JSON\n");
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Logging QUIC events\n");
+		int i = 0;
+		while(options.qlog_logging != NULL && options.qlog_logging[i] != NULL) {
+			if(!strcasecmp(options.qlog_logging[i], "quic")) {
+				IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Logging QUIC events\n");
+				qlog_quic = TRUE;
+			} else if(!strcasecmp(options.qlog_logging[i], "roq")) {
+				IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Logging RoQ events\n");
+				qlog_roq = TRUE;
+			}
+			i++;
+		}
 	}
 
 	/* Initialize the library and create a server */
@@ -173,7 +185,8 @@ int main(int argc, char *argv[]) {
 		IMQUIC_CONFIG_RAW_QUIC, options.raw_quic,
 		IMQUIC_CONFIG_WEBTRANSPORT, options.webtransport,
 		IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
-		IMQUIC_CONFIG_QLOG_QUIC, (options.qlog_path != NULL),
+		IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
+		IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
 		IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
 		IMQUIC_CONFIG_EARLY_DATA, options.early_data,
 		IMQUIC_CONFIG_DONE, NULL);

--- a/src/connection.c
+++ b/src/connection.c
@@ -198,11 +198,11 @@ imquic_connection *imquic_connection_create(imquic_network_endpoint *socket) {
 			g_snprintf(filename, sizeof(filename), "%s/imquic-%"SCNi64"-%"SCNu64".qlog",
 				conn->socket->qlog_path, g_get_real_time(), id);
 			conn->qlog = imquic_qlog_create(conn->name, conn->socket->qlog_sequential,
-				TRUE, filename, conn->socket->qlog_quic, conn->socket->qlog_moq);
+				TRUE, filename, conn->socket->qlog_quic, conn->socket->qlog_roq, conn->socket->qlog_moq);
 		} else {
 			conn->qlog = imquic_qlog_create(conn->name, conn->socket->qlog_sequential,
 				FALSE, (char *)conn->socket->qlog_path,
-				conn->socket->qlog_quic, conn->socket->qlog_moq);
+				conn->socket->qlog_quic, conn->socket->qlog_roq, conn->socket->qlog_moq);
 		}
 	}
 #endif
@@ -636,7 +636,6 @@ void imquic_connection_close(imquic_connection *conn, uint64_t error_code, uint6
 	/* FIXME Send a CONNECTION CLOSE (01c) */
 	if(conn == NULL || conn->socket == NULL)
 		return;
-	imquic_send_close_connection(conn, error_code, frame_type, reason);
 #if HAVE_QLOG
 	if(conn->qlog != NULL && conn->qlog->quic) {
 		imquic_qlog_connection_closed(conn->qlog, TRUE,
@@ -645,4 +644,5 @@ void imquic_connection_close(imquic_connection *conn, uint64_t error_code, uint6
 			reason);
 	}
 #endif
+	imquic_send_close_connection(conn, error_code, frame_type, reason);
 }

--- a/src/imquic-moq.c
+++ b/src/imquic-moq.c
@@ -72,6 +72,9 @@ imquic_server *imquic_create_moq_server(const char *name, ...) {
 			config.qlog_path = va_arg(args, char *);
 		} else if(property == IMQUIC_CONFIG_QLOG_QUIC) {
 			config.qlog_quic = va_arg(args, gboolean);
+		} else if(property == IMQUIC_CONFIG_QLOG_ROQ) {
+			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating MoQ endpoints\n", imquic_config_str(property));
+			va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_MOQ) {
 			config.qlog_moq = va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_SEQUENTIAL) {
@@ -163,6 +166,9 @@ imquic_client *imquic_create_moq_client(const char *name, ...) {
 			config.qlog_path = va_arg(args, char *);
 		} else if(property == IMQUIC_CONFIG_QLOG_QUIC) {
 			config.qlog_quic = va_arg(args, gboolean);
+		} else if(property == IMQUIC_CONFIG_QLOG_ROQ) {
+			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating MoQ endpoints\n", imquic_config_str(property));
+			va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_MOQ) {
 			config.qlog_moq = va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_SEQUENTIAL) {

--- a/src/imquic-roq.c
+++ b/src/imquic-roq.c
@@ -72,6 +72,8 @@ imquic_server *imquic_create_roq_server(const char *name, ...) {
 			config.qlog_path = va_arg(args, char *);
 		} else if(property == IMQUIC_CONFIG_QLOG_QUIC) {
 			config.qlog_quic = va_arg(args, gboolean);
+		} else if(property == IMQUIC_CONFIG_QLOG_ROQ) {
+			config.qlog_roq = va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_MOQ) {
 			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating RoQ endpoints\n", imquic_config_str(property));
 			va_arg(args, gboolean);
@@ -163,6 +165,8 @@ imquic_client *imquic_create_roq_client(const char *name, ...) {
 			config.qlog_path = va_arg(args, char *);
 		} else if(property == IMQUIC_CONFIG_QLOG_QUIC) {
 			config.qlog_quic = va_arg(args, gboolean);
+		} else if(property == IMQUIC_CONFIG_QLOG_ROQ) {
+			config.qlog_roq = va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_MOQ) {
 			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating RoQ endpoints\n", imquic_config_str(property));
 			va_arg(args, gboolean);

--- a/src/imquic.c
+++ b/src/imquic.c
@@ -239,6 +239,9 @@ imquic_server *imquic_create_server(const char *name, ...) {
 			config.qlog_path = va_arg(args, char *);
 		} else if(property == IMQUIC_CONFIG_QLOG_QUIC) {
 			config.qlog_quic = va_arg(args, gboolean);
+		} else if(property == IMQUIC_CONFIG_QLOG_ROQ) {
+			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating generic endpoints\n", imquic_config_str(property));
+			va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_MOQ) {
 			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating generic endpoints\n", imquic_config_str(property));
 			va_arg(args, gboolean);
@@ -314,6 +317,9 @@ imquic_client *imquic_create_client(const char *name, ...) {
 			config.qlog_path = va_arg(args, char *);
 		} else if(property == IMQUIC_CONFIG_QLOG_QUIC) {
 			config.qlog_quic = va_arg(args, gboolean);
+		} else if(property == IMQUIC_CONFIG_QLOG_ROQ) {
+			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating generic endpoints\n", imquic_config_str(property));
+			va_arg(args, gboolean);
 		} else if(property == IMQUIC_CONFIG_QLOG_MOQ) {
 			IMQUIC_LOG(IMQUIC_LOG_WARN, "%s is ignored when creating generic endpoints\n", imquic_config_str(property));
 			va_arg(args, gboolean);

--- a/src/imquic/imquic.h
+++ b/src/imquic/imquic.h
@@ -270,6 +270,9 @@ typedef enum imquic_config {
 	/*! \brief Whether to save QUIC events to QLOG (true by default)
 	 * \note This property is ignored if QLOG support was not compiled */
 	IMQUIC_CONFIG_QLOG_QUIC,
+	/*! \brief Whether to save RoQ events to QLOG
+	 * \note This property is ignored if QLOG support was not compiled */
+	IMQUIC_CONFIG_QLOG_ROQ,
 	/*! \brief Whether to save MoQ events to QLOG
 	 * \note This property is ignored if QLOG support was not compiled */
 	IMQUIC_CONFIG_QLOG_MOQ,

--- a/src/internal/configuration.h
+++ b/src/internal/configuration.h
@@ -55,8 +55,8 @@ typedef struct imquic_configuration {
 	const char *qlog_path;
 	/*! \brief Whether sequential JSON should be used for the QLOG file, instead of regular JSON  */
 	gboolean qlog_sequential;
-	/*! \brief Whether QUIC and/or MoQT events should be saved to QLOG, if supported */
-	gboolean qlog_quic, qlog_moq;
+	/*! \brief Whether QUIC and/or RoQ and/or MoQT events should be saved to QLOG, if supported */
+	gboolean qlog_quic, qlog_roq, qlog_moq;
 	/*! \brief Path to the certificate file to use for TLS */
 	const char *cert_pem;
 	/*! \brief Path to the key file to use for TLS */

--- a/src/internal/network.h
+++ b/src/internal/network.h
@@ -109,8 +109,8 @@ typedef struct imquic_network_endpoint {
 	char *qlog_path;
 	/*! \brief Whether sequential JSON should be used for the QLOG file, instead of regular JSON  */
 	gboolean qlog_sequential;
-	/*! \brief Whether QUIC and/or MoQT events should be saved to QLOG, if supported */
-	gboolean qlog_quic, qlog_moq;
+	/*! \brief Whether QUIC and/or RoQ and/or MoQT events should be saved to QLOG, if supported */
+	gboolean qlog_quic, qlog_roq, qlog_moq;
 	/*! \brief Mutex */
 	imquic_mutex mutex;
 	/*! \brief Whether this connection has been started */

--- a/src/internal/qlog.h
+++ b/src/internal/qlog.h
@@ -54,8 +54,8 @@ typedef struct imquic_qlog {
 	gboolean sequential;
 	/*! \brief Whether this is for a client or server connection */
 	gboolean is_server;
-	/*! \brief Whether QUIC and/or MoQT events should be saved */
-	gboolean quic, moq;
+	/*! \brief Whether QUIC and/or RoQ and/or MoQT events should be saved */
+	gboolean quic, roq, moq;
 	/*! \brief Jansson JSON instance */
 	json_t *root;
 	/*! \brief Reference to the common fields entry */
@@ -85,9 +85,11 @@ typedef struct imquic_qlog {
  * @param is_server Whether this is for a client or server connection
  * @param filename Path to where the JSON file should be saved
  * @param quic Whether QUIC events should be added to the QLOG
- * @param moq Whether MoQ events should be added to the QLOG
+ * @param roq Whether RoQ events should be added to the QLOG
+ * @param moq Whether MoQT events should be added to the QLOG
  * @returns A pointer to a new imquic_qlog instance, if successful, or NULL otherwise */
-imquic_qlog *imquic_qlog_create(char *id, gboolean sequential, gboolean is_server, char *filename, gboolean quic, gboolean moq);
+imquic_qlog *imquic_qlog_create(char *id, gboolean sequential, gboolean is_server,
+	char *filename, gboolean quic, gboolean roq, gboolean moq);
 /*! \brief Set/update the Original Destination Connection ID
  * @param qlog The imquic_qlog instance to update
  * @param odcid The Original Destination Connection ID to write, as a imquic_connection_id instance */

--- a/src/internal/roq.h
+++ b/src/internal/roq.h
@@ -21,6 +21,7 @@
 #include <glib.h>
 
 #include "../imquic/imquic.h"
+#include "qlog.h"
 #include "mutex.h"
 #include "refcount.h"
 
@@ -93,5 +94,44 @@ void imquic_roq_datagram_incoming(imquic_connection *conn, uint8_t *bytes, uint6
  * @param conn The imquic_connection instance that is now gone */
 void imquic_roq_connection_gone(imquic_connection *conn);
 ///@}
+
+#ifdef HAVE_QLOG
+/** @name QLOG events tracing for RoQ
+ */
+///@{
+/*! \brief Helper to add fields for RtpPacket to an event
+ * @param data The data object to add the properties to
+ * @param flow_id The RoQ flow ID to add
+ * @param length The length of the RTP packet */
+void imquic_roq_qlog_add_rtp_packet(json_t *data, uint64_t flow_id, uint64_t length);
+/*! \brief Add a \c stream_opened event
+ * @param qlog The imquic_qlog instance to add the event to
+ * @param stream_id The Stream ID that was opened
+ * @param flow_id The RoQ flow ID used in the stream */
+void imquic_roq_qlog_stream_opened(imquic_qlog *qlog, uint64_t stream_id, uint64_t flow_id);
+/*! \brief Add a \c stream_packet_created event
+ * @param qlog The imquic_qlog instance to add the event to
+ * @param stream_id The Stream ID used for the packet
+ * @param flow_id The RoQ flow ID used in the stream
+ * @param length The length of the RTP packet */
+void imquic_roq_qlog_stream_packet_created(imquic_qlog *qlog, uint64_t stream_id, uint64_t flow_id, uint64_t length);
+/*! \brief Add a \c stream_packet_parsed event
+ * @param qlog The imquic_qlog instance to add the event to
+ * @param stream_id The Stream ID used for the packet
+ * @param flow_id The RoQ flow ID used in the stream
+ * @param length The length of the RTP packet */
+void imquic_roq_qlog_stream_packet_parsed(imquic_qlog *qlog, uint64_t stream_id, uint64_t flow_id, uint64_t length);
+/*! \brief Add a \c datagram_packet_created event
+ * @param qlog The imquic_qlog instance to add the event to
+ * @param flow_id The RoQ flow ID used in the datagram
+ * @param length The length of the RTP packet */
+void imquic_roq_qlog_datagram_packet_created(imquic_qlog *qlog, uint64_t flow_id, uint64_t length);
+/*! \brief Add a \c datagram_packet_parsed event
+ * @param qlog The imquic_qlog instance to add the event to
+ * @param flow_id The RoQ flow ID used in the datagram
+ * @param length The length of the RTP packet */
+void imquic_roq_qlog_datagram_packet_parsed(imquic_qlog *qlog, uint64_t flow_id, uint64_t length);
+///@}
+#endif
 
 #endif

--- a/src/moq.c
+++ b/src/moq.c
@@ -91,7 +91,7 @@ void imquic_moq_new_connection(imquic_connection *conn, void *user_data) {
 		/* FIXME Generate a CLIENT_SETUP */
 		uint8_t parameters[100];
 		size_t params_num = 0, params_size = sizeof(parameters), params_len = 0;
-		if(moq->version < IMQUIC_MOQ_VERSION_08 || moq->version > IMQUIC_MOQ_VERSION_09) {
+		if(moq->version < IMQUIC_MOQ_VERSION_08) {
 			params_num++;
 			params_len += imquic_moq_parameter_add_int(moq, parameters, params_size,
 				IMQUIC_MOQ_PARAM_ROLE, moq->type);

--- a/src/network.c
+++ b/src/network.c
@@ -451,10 +451,11 @@ imquic_network_endpoint *imquic_network_endpoint_create(imquic_configuration *co
 		}
 		if(ne->qlog_path != NULL) {
 			ne->qlog_quic = config->qlog_quic;
+			ne->qlog_roq = config->qlog_roq;
 			ne->qlog_moq = config->qlog_moq;
 			ne->qlog_sequential = config->qlog_sequential;
-			if(!ne->qlog_quic && !ne->qlog_moq) {
-				IMQUIC_LOG(IMQUIC_LOG_WARN, "[%s] Tracing of at least one of QUIC and MoQ should be enabled, disabling QLOG\n", config->name);
+			if(!ne->qlog_quic && !ne->qlog_roq && !ne->qlog_moq) {
+				IMQUIC_LOG(IMQUIC_LOG_WARN, "[%s] Tracing of at least one of QUIC, RoQ and MoQ should be enabled, disabling QLOG\n", config->name);
 				g_free(ne->qlog_path);
 				ne->qlog_path = NULL;
 			}

--- a/src/qlog.c
+++ b/src/qlog.c
@@ -48,11 +48,12 @@ static void imquic_qlog_free(const imquic_refcount *qlog_ref) {
 	g_free(qlog);
 }
 
-imquic_qlog *imquic_qlog_create(char *id, gboolean sequential, gboolean is_server, char *filename, gboolean quic, gboolean moq) {
+imquic_qlog *imquic_qlog_create(char *id, gboolean sequential, gboolean is_server,
+		char *filename, gboolean quic, gboolean roq, gboolean moq) {
 	if(id == NULL || filename == NULL)
 		return NULL;
-	if(!quic && !moq) {
-		IMQUIC_LOG(IMQUIC_LOG_ERR, "[%s] Can't create QLOG instance, at least one of QUIC and MoQ should be enabled\n", id);
+	if(!quic && !roq && !moq) {
+		IMQUIC_LOG(IMQUIC_LOG_ERR, "[%s] Can't create QLOG instance, at least one of QUIC, RoQ and MoQ should be enabled\n", id);
 		return NULL;
 	}
 	imquic_qlog *qlog = g_malloc0(sizeof(imquic_qlog));
@@ -68,6 +69,7 @@ imquic_qlog *imquic_qlog_create(char *id, gboolean sequential, gboolean is_serve
 	qlog->is_server = is_server;
 	qlog->filename = g_strdup(filename);
 	qlog->quic = quic;
+	qlog->roq = roq;
 	qlog->moq = moq;
 	/* Initialize the QLOG structure */
 	qlog->root = json_object();
@@ -82,6 +84,10 @@ imquic_qlog *imquic_qlog_create(char *id, gboolean sequential, gboolean is_serve
 	if(quic) {
 		json_array_append_new(schemas, json_string("urn:ietf:params:qlog:events:quic-09"));
 		json_array_append_new(protocols, json_string("QUIC"));
+	}
+	if(roq) {
+		json_array_append_new(schemas, json_string("urn:ietf:params:qlog:events:roq-00"));
+		json_array_append_new(protocols, json_string("ROQ"));
 	}
 	if(moq) {
 		json_array_append_new(schemas, json_string("urn:ietf:params:qlog:events:moqt-00"));


### PR DESCRIPTION
Considering that we have support for QLOG MoQ traces, I decided to add them for RoQ as well, using [this draft](https://www.ietf.org/archive/id/draft-engelbart-qlog-roq-events-00.html). It's probably a temporary draft (it's expired) but it's good to have as a placeholder to at least have traces of something, when we need them.