### PR TITLE
Fix compilation when linking against BoringSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To compile imquic, you'll need to satisfy the following dependencies:
 * [quictls](https://quictls.github.io/) (QUIC TLS)
 * [Jansson](https://github.com/akheron/jansson) (optional; QLOG support)
 
+> **Note:** You can also use BoringSSL, instead of quictls, by passing `--enable-boringssl=</path/to/boringssl>`, albeit without early-data support. If BoringSSL is installed in `/opt/boringssl`, the configure script will expect header files in `/opt/boringssl/include` and shared (not static) objects in `/opt/boringssl/lib64`. You'll then need to manually export `LD_LIBRARY_PATH` to the path where BoringSSL shared objects are, when using an application that's linked to the library.
 
 Should you be interested in building the imquic documentation as well (public and internal), you'll need some additional tools too:
 

--- a/configure.ac
+++ b/configure.ac
@@ -109,9 +109,9 @@ AS_IF([test "x${boringssl_dir}" != "x"],
       [echo "Trying to use BoringSSL instead of quictls...";
        AC_MSG_NOTICE([BoringSSL directory is ${boringssl_dir}])
        CFLAGS="$CFLAGS -I${boringssl_dir}/include";
-       BORINGSSL_CFLAGS=" -I${boringssl_dir}/include";
+       BORINGSSL_CFLAGS="-I${boringssl_dir}/include";
        AC_SUBST(BORINGSSL_CFLAGS)
-       BORINGSSL_LIBS=" -L${boringssl_dir}/lib -lstdc++";
+       BORINGSSL_LIBS="-lstdc++ -L${boringssl_dir}/lib64 -lssl -lcrypto";
        AC_SUBST(BORINGSSL_LIBS)
        AC_CHECK_HEADERS([${boringssl_dir}/include/openssl/opensslconf.h],
                         [AC_DEFINE(IMQUIC_BORINGSSL)],


### PR DESCRIPTION
The library initially supported both BoringSSL and quictls, before I spent more time on quictls itself. Since BoringSSL was not working anymore when I tested it, this patch should fix it. It also manually disables early data when using BoringSSL, since BoringSSL and quictls do it differently, and I haven't investigated if there's a simple way to conditionally add the BoringSSL way to do it.