### PR TITLE
Fix loading of chain certificates

### DIFF
--- a/src/internal/crypto.h
+++ b/src/internal/crypto.h
@@ -49,10 +49,8 @@ typedef struct imquic_tls {
 	gboolean is_server;
 	/*! \brief TLS context */
 	SSL_CTX *ssl_ctx;
-	/*! \brief Certificate */
-	X509 *ssl_cert;
-	/*! \brief Key */
-	EVP_PKEY *ssl_key;
+	/*! \brief Key password, if needed */
+	char *key_pwd;
 	/*! \brief Whether early data should be supported */
 	gboolean early_data;
 	/*! \brief File to use for session tickets, when doing early data */


### PR DESCRIPTION
My use of `PEM_read_X509` was loading a single certificate even when passing a full chain (like a LetsEncrypt one). This patch changes the way we load certificate and key, by switching to `SSL_CTX_use_certificate_chain_file`, `SSL_CTX_use_PrivateKey_file` and `SSL_CTX_set_default_passwd_cb_userdata`, which seems to have fixed it.