### PR TITLE
Refactored RoQ client/server demos to more generic sender/receiver demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 imquic-echo-client
 imquic-echo-server
-imquic-roq-client
-imquic-roq-server
+imquic-roq-sender
+imquic-roq-receiver
 imquic-moq-pub
 imquic-moq-sub
 imquic-moq-chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to this project will be documented in this file.
 - Switched to picoquic as the underlying QUIC stack
 - Added support for external logging functions
 - Added support for MoQT v17-v18, and dropped support for MoQT v11-v15
+- Refactored RoQ client/server examples to more generic sender/receiver

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -112,33 +112,33 @@ endif
 
 if ENABLE_ROQ_EXAMPLES
 
-bin_PROGRAMS += imquic-roq-server imquic-roq-client
+bin_PROGRAMS += imquic-roq-receiver imquic-roq-sender
 
-imquic_roq_server_SOURCES = \
-	roq-server.c \
-	roq-server-options.c \
-	roq-server-options.h
-imquic_roq_server_CFLAGS = \
+imquic_roq_receiver_SOURCES = \
+	roq-receiver.c \
+	roq-receiver-options.c \
+	roq-receiver-options.h
+imquic_roq_receiver_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(IMQUIC_CFLAGS) \
 	-I ../src \
 	$(NULL)
-imquic_roq_server_LDADD = \
+imquic_roq_receiver_LDADD = \
 	$(IMQUIC_LIBS) \
 	$(IMQUIC_MANUAL_LIBS) \
 	-L../src/.libs -limquic \
 	$(NULL)
 
-imquic_roq_client_SOURCES = \
-	roq-client.c \
-	roq-client-options.c \
-	roq-client-options.h
-imquic_roq_client_CFLAGS = \
+imquic_roq_sender_SOURCES = \
+	roq-sender.c \
+	roq-sender-options.c \
+	roq-sender-options.h
+imquic_roq_sender_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(IMQUIC_CFLAGS) \
 	-I ../src \
 	$(NULL)
-imquic_roq_client_LDADD = \
+imquic_roq_sender_LDADD = \
 	$(IMQUIC_LIBS) \
 	$(IMQUIC_MANUAL_LIBS) \
 	-L../src/.libs -limquic \

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,24 +44,26 @@ In both cases, the client will then send a single `ciao` buffer on a bidirection
 
 To build the RTP Over QUIC (RoQ) examples, pass `--enable-roq-examples` to the `./configure` script. This will build two command line applications, namely:
 
-* `imquic-roq-server`, a basic RoQ server, that can print the flow ID and RTP headers of the incoming packets, and/or echo packets back;
-* `imquic-roq-client`, a basic RoQ client, that will listen for RTP packets on some UDP ports, and restream them via QUIC.
+* `imquic-roq-sender`, a basic RoQ sender, that will listen for RTP packets on some UDP ports, and restream them via QUIC.
+* `imquic-roq-receiver`, a basic RoQ receiver, that can print the flow ID and RTP headers of the incoming packets, and/or echo packets back;
 
-Both provide a few configuration options: pass `-h` or `--help` for more information.
+Both demos can act as either a server or a client, and provide a few configuration options: pass `-h` or `--help` for more information.
 
-This launches the RoQ server on port `9000`, using the provided certificate; raw QUIC is used (`-q`), but unlike before the ALPN is omitted, since it will automatically be set by the RoQ stack in the library:
+This launches the RoQ receiver as a server (`-o` is omitted, so the default behaviour applies) on port `9000`, using the provided certificate; raw QUIC is used (`-q`), but unlike before the ALPN is omitted, since it will automatically be set by the RoQ stack in the library:
 
-	./examples/imquic-roq-server -q -p 9000 -c ../localhost.crt -k ../localhost.key
+	./examples/imquic-roq-receiver -q -p 9000 -c ../localhost.crt -k ../localhost.key
 
-Since no other parameter is provided, the default behaviour is just to print some detail about incoming packets. To not show such information, the `-Z` or `--quiet` flag can be passed. The RoQ server can also be configured to echo packets back to the client via `-e` or `--echo`. This launches the same RoQ server as before, but in quiet (`-Z`) and echo (`-e`) mode and on WebTransport too (`-w`):
+Since no other parameter is provided, the default behaviour is just to print some detail about incoming packets. To not show such information, the `-Z` or `--quiet` flag can be passed. The RoQ receiver can also be configured to echo packets back to the client via `-e` or `--echo`. This launches the same RoQ server as before, but in quiet (`-Z`) and echo (`-e`) mode and on WebTransport too (`-w`):
 
-	./examples/imquic-roq-server -w -q -p 9000 -Z -e -c ../localhost.crt -k ../localhost.key
+	./examples/imquic-roq-receiver -w -q -p 9000 -Z -e -c ../localhost.crt -k ../localhost.key
 
-This instead launches the RoQ client to connect to that server (whether in echo mode or not), waiting for audio RTP packets on port `15002` (whose flow ID on RoQ will be `0`) and for video RTP packets on port `15004` (whose flow ID on RoQ will be `1`), and using a separate `STREAM` for each RTP packet:
+This instead launches the RoQ sender as a client (`-o`) to connect to that server (whether in echo mode or not), waiting for audio RTP packets on port `15002` (whose flow ID on RoQ will be `0`) and for video RTP packets on port `15004` (whose flow ID on RoQ will be `1`), and using a separate `STREAM` for each RTP packet:
 
-	./examples/imquic-roq-client -q -a 15002 -A 0 -v 15004 -V 1 -r 127.0.0.1 -R 9000 -m streams
+	./examples/imquic-roq-sender -o -q -a 15002 -A 0 -v 15004 -V 1 -r 127.0.0.1 -R 9000 -m streams
 
-Sending RTP traffic to those ports (e.g., from GStreamer, FFmpeg, Janus RTP forwarders or others), will have the RoQ client send them to the RoQ server.
+Sending RTP traffic to those ports (e.g., from GStreamer, FFmpeg, Janus RTP forwarders or others), will have the RoQ sender send them to the RoQ receiver.
+
+Since both demos can act as both client and server, it's possible to reverse the QUIC roles of this demo. When a sender acts as a server, it will relay RTP packets via RoQ to all the receiver clients that connect.
 
 ## Media Over QUIC (MoQ) examples
 

--- a/examples/roq-receiver-options.c
+++ b/examples/roq-receiver-options.c
@@ -4,39 +4,36 @@
  * Author:  Lorenzo Miniero <lorenzo@meetecho.com>
  * License: MIT
  *
- * Command line options for imquic-roq-client
+ * Command line options for imquic-roq-receiver
  *
  */
 
-#include "roq-client-options.h"
+#include "roq-receiver-options.h"
 
 static GOptionContext *opts = NULL;
 
 gboolean demo_options_parse(demo_options *options, int argc, char *argv[]) {
 	/* Supported command-line arguments */
 	GOptionEntry opt_entries[] = {
-		{ "audio-port", 'a', 0, G_OPTION_ARG_INT, &options->audio_port, "Port to bind to for incoming audio RTP packets (default=none)", "port" },
-		{ "audio-flow", 'A', 0, G_OPTION_ARG_INT, &options->audio_flow, "Flow ID of the audio RTP stream (default=none)", "number" },
-		{ "video-port", 'v', 0, G_OPTION_ARG_INT, &options->video_port, "Port to bind to for incoming video RTP packets (default=none)", "port" },
-		{ "video-flow", 'V', 0, G_OPTION_ARG_INT, &options->video_flow, "Flow ID of the video RTP stream (default=none)", "number" },
-		{ "multiplexing", 'm', 0, G_OPTION_ARG_STRING, &options->multiplexing, "RTP multiplexing (datagram, stream or streams; default=datagram)", "mode" },
+		{ "client", 'o', 0, G_OPTION_ARG_NONE, &options->client, "Act as a QUIC client, not as a server (default=server)", NULL },
 		{ "bind", 'b', 0, G_OPTION_ARG_STRING, &options->ip, "Local IP address to bind to (default=all interfaces)", "IP" },
 		{ "port", 'p', 0, G_OPTION_ARG_INT, &options->port, "Local port to bind to (default=0, random)", "port" },
-		{ "remote-host", 'r', 0, G_OPTION_ARG_STRING, &options->remote_host, "QUIC server to connect to (default=none)", "IP" },
-		{ "remote-port", 'R', 0, G_OPTION_ARG_INT, &options->remote_port, "Port of the QUIC server (default=none)", "port" },
+		{ "remote-host", 'r', 0, G_OPTION_ARG_STRING, &options->remote_host, "When acting as a client, QUIC server to connect to (default=none)", "IP" },
+		{ "remote-port", 'R', 0, G_OPTION_ARG_INT, &options->remote_port, "When acting as a client, port of the QUIC server (default=none)", "port" },
 		{ "sni", 'S', 0, G_OPTION_ARG_STRING, &options->sni, "SNI to use (default=localhost)", "sni" },
-		{ "raw-quic", 'q', 0, G_OPTION_ARG_NONE, &options->raw_quic, "Whether raw QUIC should be offered for the RoQ connection or not (default=no)", NULL },
+		{ "raw-quic", 'q', 0, G_OPTION_ARG_NONE, &options->raw_quic, "Whether raw QUIC should be offered for RoQ connections or not (default=no)", NULL },
 		{ "webtransport", 'w', 0, G_OPTION_ARG_NONE, &options->webtransport, "Whether WebTransport should be offered for the RoQ connection or not (default=no)", NULL },
 		{ "path", 'H', 0, G_OPTION_ARG_STRING, &options->path, "In case WebTransport is used, path to use for the HTTP/3 request (default=/)", "HTTP/3 path" },
 		{ "cert-pem", 'c', 0, G_OPTION_ARG_STRING, &options->cert_pem, "Certificate to use (default=none)", "path" },
 		{ "cert-key", 'k', 0, G_OPTION_ARG_STRING, &options->cert_key, "Certificate key to use (default=none)", "path" },
-		{ "zero-rtt", '0', 0, G_OPTION_ARG_STRING, &options->ticket_file, "Whether early data via 0-RTT should be supported, and what file to use for writing/reading the session ticket (default=none)", "path" },
+		{ "zero-rtt", '0', 0, G_OPTION_ARG_STRING, &options->ticket_file, "Whether early data via 0-RTT should be supported, and, when acting as client, what file to use for writing/reading the session ticket (default=none)", "path" },
 		{ "secrets-log", 's', 0, G_OPTION_ARG_STRING, &options->secrets_log, "Save the exchanged secrets to a file compatible with Wireshark (default=none)", "path" },
-		{ "qlog-path", 'Q', 0, G_OPTION_ARG_STRING, &options->qlog_path, "Path to a folder where to save QLOG files for this connection (default=none)", "path" },
+		{ "qlog-path", 'Q', 0, G_OPTION_ARG_STRING, &options->qlog_path, "Path to a folder where to save QLOG files for all connections (default=none)", "path" },
 		{ "qlog-logging", 'l', 0, G_OPTION_ARG_STRING_ARRAY, &options->qlog_logging, "Save these events to QLOG (can be called multiple times to save multiple things; default=none)", "quic|http3|roq" },
 		{ "qlog-sequential", 'J', 0, G_OPTION_ARG_NONE, &options->qlog_sequential, "Whether sequential JSON should be used for the QLOG file, instead of regular JSON (default=no)", NULL },
 		{ "qlog-rtp-packets", 'y', 0, G_OPTION_ARG_NONE, &options->qlog_roq_packets, "Whether the payload of RoQ RTP packets should be saved to QLOG file (default=no)", NULL },
-		{ "quiet", 'Z', 0, G_OPTION_ARG_NONE, &options->quiet, "If set, don't print about incoming/outgoing RTP packets on stdout (default=no)", NULL },
+		{ "quiet", 'Z', 0, G_OPTION_ARG_NONE, &options->quiet, "If set, don't print about incoming/outgoing packets on stdout (default=no)", NULL },
+		{ "echo", 'e', 0, G_OPTION_ARG_NONE, &options->echo, "If set, the receiver will echo incoming RTP packets back to the sender (default=no)", NULL },
 		{ "debug-level", 'd', 0, G_OPTION_ARG_INT, &options->debug_level, "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)", "1-7" },
 		{ "debug-locks", 'L', 0, G_OPTION_ARG_NONE, &options->debug_locks, "Whether to verbosely debug mutex/lock accesses (default=no)", NULL },
 		{ "debug-refcounts", 'C', 0, G_OPTION_ARG_NONE, &options->debug_refcounts, "Whether to verbosely debug reference counting (default=no)", NULL },

--- a/examples/roq-receiver-options.h
+++ b/examples/roq-receiver-options.h
@@ -4,24 +4,29 @@
  * Author:  Lorenzo Miniero <lorenzo@meetecho.com>
  * License: MIT
  *
- * Command line options for imquic-roq-server
+ * Command line options for imquic-roq-receiver
  *
  */
 
-#ifndef ROQ_SERVER_OPTIONS
-#define ROQ_SERVER_OPTIONS
+#ifndef ROQ_RECEIVER_OPTIONS
+#define ROQ_RECEIVER_OPTIONS
 
 #include <glib.h>
 
 /*! \brief Struct containing the parsed command line options */
 typedef struct demo_options {
+	gboolean client;
 	const char *ip;
 	int port;
+	const char *remote_host;
+	int remote_port;
+	const char *sni;
 	gboolean raw_quic;
 	gboolean webtransport;
+	const char *path;
 	const char *cert_pem;
 	const char *cert_key;
-	gboolean early_data;
+	const char *ticket_file;
 	const char *secrets_log;
 	const char *qlog_path;
 	const char **qlog_logging;

--- a/examples/roq-receiver.c
+++ b/examples/roq-receiver.c
@@ -4,7 +4,7 @@
  * Author:  Lorenzo Miniero <lorenzo@meetecho.com>
  * License: MIT
  *
- * Basic RoQ server
+ * Basic RoQ receiver (client or server)
  *
  */
 
@@ -13,7 +13,7 @@
 #include <imquic/imquic.h>
 #include <imquic/roq.h>
 
-#include "roq-server-options.h"
+#include "roq-receiver-options.h"
 
 /* Command line options */
 static demo_options options = { 0 };
@@ -23,7 +23,7 @@ static volatile int stop = 0;
 static void imquic_demo_handle_signal(int signum) {
 	switch(g_atomic_int_get(&stop)) {
 		case 0:
-			IMQUIC_PRINT("Stopping server, please wait...\n");
+			IMQUIC_PRINT("Stopping receiver, please wait...\n");
 			break;
 		case 1:
 			IMQUIC_PRINT("In a hurry? I'm trying to free resources cleanly, here!\n");
@@ -115,11 +115,24 @@ static void imquic_demo_rtp_incoming(imquic_connection *conn, imquic_roq_multipl
 	}
 }
 
+static void imquic_demo_connection_failed(void *user_data) {
+	/* Connection failed */
+	IMQUIC_LOG(IMQUIC_LOG_INFO, "Connection failed\n");
+	if(options.client) {
+		/* Stop here */
+		g_atomic_int_inc(&stop);
+	}
+}
+
 static void imquic_demo_connection_gone(imquic_connection *conn, uint64_t error_code, const char *reason) {
 	/* Connection was closed */
-	IMQUIC_LOG(IMQUIC_LOG_INFO, "[%s] RoQ connection gone\n", imquic_get_connection_name(conn));
+	IMQUIC_LOG(IMQUIC_LOG_INFO, "[%s] Connection gone\n", imquic_get_connection_name(conn));
 	if(g_hash_table_remove(connections, conn))
 		imquic_connection_unref(conn);
+	if(options.client) {
+		/* Stop here */
+		g_atomic_int_inc(&stop);
+	}
 }
 
 int main(int argc, char *argv[]) {
@@ -148,8 +161,14 @@ int main(int argc, char *argv[]) {
 		imquic_set_refcount_debugging(TRUE);
 
 	int ret = 0;
-	if(options.cert_pem == NULL || strlen(options.cert_pem) == 0 || options.cert_key == NULL || strlen(options.cert_key) == 0) {
-		IMQUIC_LOG(IMQUIC_LOG_FATAL, "Missing certificate/key\n");
+	IMQUIC_LOG(IMQUIC_LOG_INFO, "RoQ receiver will act as a %s\n", options.client ? "client (single connection)" : "server (multiple connections)");
+	if(options.client && (options.remote_host == NULL || options.remote_port == 0)) {
+		IMQUIC_LOG(IMQUIC_LOG_FATAL, "Invalid QUIC server address (required when acting as client)\n");
+		ret = 1;
+		goto done;
+	}
+	if(!options.client && (options.cert_pem == NULL || strlen(options.cert_pem) == 0 || options.cert_key == NULL || strlen(options.cert_key) == 0)) {
+		IMQUIC_LOG(IMQUIC_LOG_FATAL, "Missing certificate/key (required when acting as server)\n");
 		ret = 1;
 		goto done;
 	}
@@ -163,8 +182,11 @@ int main(int argc, char *argv[]) {
 		ret = 1;
 		goto done;
 	}
-	if(options.early_data)
+	if(options.ticket_file != NULL) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "Early data support enabled\n");
+		if(options.client)
+			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Ticket file '%s'\n", options.ticket_file);
+	}
 
 	/* Check if we need to create a QLOG file */
 	gboolean qlog_quic = FALSE, qlog_http3 = FALSE, qlog_roq = FALSE;
@@ -195,60 +217,87 @@ int main(int argc, char *argv[]) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "Echo mode (will send incoming RTP packets back to the client)\n");
 	IMQUIC_LOG(IMQUIC_LOG_INFO, "\n");
 
-	/* Initialize the library and create a server */
+	/* Initialize the library and create a client or server endpoint */
 	if(imquic_init(options.secrets_log) < 0) {
 		ret = 1;
 		goto done;
 	}
-	imquic_server *server = imquic_create_roq_server("roq-server",
-		IMQUIC_CONFIG_INIT,
-		IMQUIC_CONFIG_TLS_CERT, options.cert_pem,
-		IMQUIC_CONFIG_TLS_KEY, options.cert_key,
-		IMQUIC_CONFIG_TLS_NO_VERIFY, TRUE,
-		IMQUIC_CONFIG_LOCAL_BIND, options.ip,
-		IMQUIC_CONFIG_LOCAL_PORT, options.port,
-		IMQUIC_CONFIG_RAW_QUIC, options.raw_quic,
-		IMQUIC_CONFIG_WEBTRANSPORT, options.webtransport,
-		IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
-		IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
-		IMQUIC_CONFIG_QLOG_HTTP3, qlog_http3,
-		IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
-		IMQUIC_CONFIG_QLOG_ROQ_PACKETS, options.qlog_roq_packets,
-		IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
-		IMQUIC_CONFIG_EARLY_DATA, options.early_data,
-		IMQUIC_CONFIG_DONE, NULL);
-	if(server == NULL) {
+	imquic_endpoint *endpoint = NULL;
+	if(options.client) {
+		endpoint = imquic_create_roq_client("roq-receiver-client",
+			IMQUIC_CONFIG_INIT,
+			IMQUIC_CONFIG_TLS_CERT, options.cert_pem,
+			IMQUIC_CONFIG_TLS_KEY, options.cert_key,
+			IMQUIC_CONFIG_TLS_NO_VERIFY, TRUE,
+			IMQUIC_CONFIG_LOCAL_BIND, options.ip,
+			IMQUIC_CONFIG_LOCAL_PORT, options.port,
+			IMQUIC_CONFIG_REMOTE_HOST, options.remote_host,
+			IMQUIC_CONFIG_REMOTE_PORT, options.remote_port,
+			IMQUIC_CONFIG_SNI, options.sni,
+			IMQUIC_CONFIG_RAW_QUIC, options.raw_quic,
+			IMQUIC_CONFIG_WEBTRANSPORT, options.webtransport,
+			IMQUIC_CONFIG_EARLY_DATA, (options.ticket_file != NULL),
+			IMQUIC_CONFIG_TICKET_FILE, options.ticket_file,
+			IMQUIC_CONFIG_HTTP3_PATH, options.path,
+			IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
+			IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
+			IMQUIC_CONFIG_QLOG_HTTP3, qlog_http3,
+			IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
+			IMQUIC_CONFIG_QLOG_ROQ_PACKETS, options.qlog_roq_packets,
+			IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
+			IMQUIC_CONFIG_DONE, NULL);
+	} else {
+		endpoint = imquic_create_roq_server("roq-receiver-server",
+			IMQUIC_CONFIG_INIT,
+			IMQUIC_CONFIG_TLS_CERT, options.cert_pem,
+			IMQUIC_CONFIG_TLS_KEY, options.cert_key,
+			IMQUIC_CONFIG_TLS_NO_VERIFY, TRUE,
+			IMQUIC_CONFIG_LOCAL_BIND, options.ip,
+			IMQUIC_CONFIG_LOCAL_PORT, options.port,
+			IMQUIC_CONFIG_RAW_QUIC, options.raw_quic,
+			IMQUIC_CONFIG_WEBTRANSPORT, options.webtransport,
+			IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
+			IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
+			IMQUIC_CONFIG_QLOG_HTTP3, qlog_http3,
+			IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
+			IMQUIC_CONFIG_QLOG_ROQ_PACKETS, options.qlog_roq_packets,
+			IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
+			IMQUIC_CONFIG_EARLY_DATA, (options.ticket_file != NULL),
+			IMQUIC_CONFIG_DONE, NULL);
+	}
+	if(endpoint == NULL) {
 		ret = 1;
 		goto done;
 	}
 	if(options.raw_quic) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "ALPN(s):\n");
 		int i = 0;
-		const char **alpns = imquic_get_endpoint_alpns(server);
+		const char **alpns = imquic_get_endpoint_alpns(endpoint);
 		while(alpns[i] != NULL) {
 			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- %s\n", alpns[i]);
 			i++;
 		}
 	}
-	if(options.webtransport && imquic_get_endpoint_wt_protocols(server) != NULL) {
+	if(options.webtransport && imquic_get_endpoint_wt_protocols(endpoint) != NULL) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "WebTransport Protocol(s):\n");
 		int i = 0;
-		const char **wt_protocols = imquic_get_endpoint_wt_protocols(server);
+		const char **wt_protocols = imquic_get_endpoint_wt_protocols(endpoint);
 		while(wt_protocols[i] != NULL) {
 			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- %s\n", wt_protocols[i]);
 			i++;
 		}
 	}
-	imquic_set_new_roq_connection_cb(server, imquic_demo_new_connection);
-	imquic_set_rtp_incoming_cb(server, imquic_demo_rtp_incoming);
-	imquic_set_roq_connection_gone_cb(server, imquic_demo_connection_gone);
+	imquic_set_new_roq_connection_cb(endpoint, imquic_demo_new_connection);
+	imquic_set_rtp_incoming_cb(endpoint, imquic_demo_rtp_incoming);
+	imquic_set_connection_failed_cb(endpoint, imquic_demo_connection_failed);
+	imquic_set_roq_connection_gone_cb(endpoint, imquic_demo_connection_gone);
 	connections = g_hash_table_new(NULL, NULL);
-	imquic_start_endpoint(server);
+	imquic_start_endpoint(endpoint);
 
 	while(!stop)
 		g_usleep(100000);
 
-	imquic_shutdown_endpoint(server);
+	imquic_shutdown_endpoint(endpoint);
 
 done:
 	imquic_deinit();

--- a/examples/roq-sender-options.c
+++ b/examples/roq-sender-options.c
@@ -4,31 +4,41 @@
  * Author:  Lorenzo Miniero <lorenzo@meetecho.com>
  * License: MIT
  *
- * Command line options for imquic-roq-server
+ * Command line options for imquic-roq-sender
  *
  */
 
-#include "roq-server-options.h"
+#include "roq-sender-options.h"
 
 static GOptionContext *opts = NULL;
 
 gboolean demo_options_parse(demo_options *options, int argc, char *argv[]) {
 	/* Supported command-line arguments */
 	GOptionEntry opt_entries[] = {
+		{ "audio-port", 'a', 0, G_OPTION_ARG_INT, &options->audio_port, "Port to bind to for incoming audio RTP packets (default=none)", "port" },
+		{ "audio-flow", 'A', 0, G_OPTION_ARG_INT, &options->audio_flow, "Flow ID of the audio RTP stream (default=none)", "number" },
+		{ "video-port", 'v', 0, G_OPTION_ARG_INT, &options->video_port, "Port to bind to for incoming video RTP packets (default=none)", "port" },
+		{ "video-flow", 'V', 0, G_OPTION_ARG_INT, &options->video_flow, "Flow ID of the video RTP stream (default=none)", "number" },
+		{ "multiplexing", 'm', 0, G_OPTION_ARG_STRING, &options->multiplexing, "RTP multiplexing (datagram, stream or streams; default=datagram)", "mode" },
+		{ "timeout", 't', 0, G_OPTION_ARG_INT, &options->timeout, "Automatically shutdown the endpoint if no RTP packets arrive for this amount of seconds (default=no timeout)", "seconds" },
+		{ "client", 'o', 0, G_OPTION_ARG_NONE, &options->client, "Act as a QUIC client, not as a server (default=server)", NULL },
 		{ "bind", 'b', 0, G_OPTION_ARG_STRING, &options->ip, "Local IP address to bind to (default=all interfaces)", "IP" },
 		{ "port", 'p', 0, G_OPTION_ARG_INT, &options->port, "Local port to bind to (default=0, random)", "port" },
-		{ "raw-quic", 'q', 0, G_OPTION_ARG_NONE, &options->raw_quic, "Whether raw QUIC should be offered for RoQ connections or not (default=no)", NULL },
+		{ "remote-host", 'r', 0, G_OPTION_ARG_STRING, &options->remote_host, "When acting as a client, QUIC server to connect to (default=none)", "IP" },
+		{ "remote-port", 'R', 0, G_OPTION_ARG_INT, &options->remote_port, "When acting as a client, port of the QUIC server (default=none)", "port" },
+		{ "sni", 'S', 0, G_OPTION_ARG_STRING, &options->sni, "SNI to use (default=localhost)", "sni" },
+		{ "raw-quic", 'q', 0, G_OPTION_ARG_NONE, &options->raw_quic, "Whether raw QUIC should be offered for the RoQ connection or not (default=no)", NULL },
 		{ "webtransport", 'w', 0, G_OPTION_ARG_NONE, &options->webtransport, "Whether WebTransport should be offered for the RoQ connection or not (default=no)", NULL },
+		{ "path", 'H', 0, G_OPTION_ARG_STRING, &options->path, "In case WebTransport is used, path to use for the HTTP/3 request (default=/)", "HTTP/3 path" },
 		{ "cert-pem", 'c', 0, G_OPTION_ARG_STRING, &options->cert_pem, "Certificate to use (default=none)", "path" },
 		{ "cert-key", 'k', 0, G_OPTION_ARG_STRING, &options->cert_key, "Certificate key to use (default=none)", "path" },
-		{ "zero-rtt", '0', 0, G_OPTION_ARG_NONE, &options->early_data, "Whether early data via 0-RTT should be supported (default=no)", NULL },
+		{ "zero-rtt", '0', 0, G_OPTION_ARG_STRING, &options->ticket_file, "Whether early data via 0-RTT should be supported, and, when acting as client, what file to use for writing/reading the session ticket (default=none)", "path" },
 		{ "secrets-log", 's', 0, G_OPTION_ARG_STRING, &options->secrets_log, "Save the exchanged secrets to a file compatible with Wireshark (default=none)", "path" },
-		{ "qlog-path", 'Q', 0, G_OPTION_ARG_STRING, &options->qlog_path, "Path to a folder where to save QLOG files for all connections (default=none)", "path" },
+		{ "qlog-path", 'Q', 0, G_OPTION_ARG_STRING, &options->qlog_path, "Path to a folder where to save QLOG files for this connection (default=none)", "path" },
 		{ "qlog-logging", 'l', 0, G_OPTION_ARG_STRING_ARRAY, &options->qlog_logging, "Save these events to QLOG (can be called multiple times to save multiple things; default=none)", "quic|http3|roq" },
 		{ "qlog-sequential", 'J', 0, G_OPTION_ARG_NONE, &options->qlog_sequential, "Whether sequential JSON should be used for the QLOG file, instead of regular JSON (default=no)", NULL },
 		{ "qlog-rtp-packets", 'y', 0, G_OPTION_ARG_NONE, &options->qlog_roq_packets, "Whether the payload of RoQ RTP packets should be saved to QLOG file (default=no)", NULL },
-		{ "quiet", 'Z', 0, G_OPTION_ARG_NONE, &options->quiet, "If set, don't print about incoming/outgoing packets on stdout (default=no)", NULL },
-		{ "echo", 'e', 0, G_OPTION_ARG_NONE, &options->echo, "If set, the server will echo incoming RTP packets back to the client (default=no)", NULL },
+		{ "quiet", 'Z', 0, G_OPTION_ARG_NONE, &options->quiet, "If set, don't print about incoming/outgoing RTP packets on stdout (default=no)", NULL },
 		{ "debug-level", 'd', 0, G_OPTION_ARG_INT, &options->debug_level, "Debug/logging level (0=disable debugging, 7=maximum debug level; default=4)", "1-7" },
 		{ "debug-locks", 'L', 0, G_OPTION_ARG_NONE, &options->debug_locks, "Whether to verbosely debug mutex/lock accesses (default=no)", NULL },
 		{ "debug-refcounts", 'C', 0, G_OPTION_ARG_NONE, &options->debug_refcounts, "Whether to verbosely debug reference counting (default=no)", NULL },

--- a/examples/roq-sender-options.h
+++ b/examples/roq-sender-options.h
@@ -4,12 +4,12 @@
  * Author:  Lorenzo Miniero <lorenzo@meetecho.com>
  * License: MIT
  *
- * Command line options for imquic-roq-client
+ * Command line options for imquic-roq-sender
  *
  */
 
-#ifndef ROQ_CLIENT_OPTIONS
-#define ROQ_CLIENT_OPTIONS
+#ifndef ROQ_SENDER_OPTIONS
+#define ROQ_SENDER_OPTIONS
 
 #include <glib.h>
 
@@ -20,6 +20,8 @@ typedef struct demo_options {
 	int video_flow;
 	int video_port;
 	const char *multiplexing;
+	int timeout;
+	gboolean client;
 	const char *ip;
 	int port;
 	const char *remote_host;

--- a/examples/roq-sender.c
+++ b/examples/roq-sender.c
@@ -4,7 +4,7 @@
  * Author:  Lorenzo Miniero <lorenzo@meetecho.com>
  * License: MIT
  *
- * Basic RoQ client
+ * Basic RoQ sender (client or server)
  *
  */
 
@@ -24,7 +24,7 @@
 #include <imquic/imquic.h>
 #include <imquic/roq.h>
 
-#include "roq-client-options.h"
+#include "roq-sender-options.h"
 
 /* Command line options */
 static demo_options options = { 0 };
@@ -34,7 +34,7 @@ static volatile int stop = 0;
 static void imquic_demo_handle_signal(int signum) {
 	switch(g_atomic_int_get(&stop)) {
 		case 0:
-			IMQUIC_PRINT("Stopping server, please wait...\n");
+			IMQUIC_PRINT("Stopping sender, please wait...\n");
 			break;
 		case 1:
 			IMQUIC_PRINT("In a hurry? I'm trying to free resources cleanly, here!\n");
@@ -47,6 +47,10 @@ static void imquic_demo_handle_signal(int signum) {
 	if(g_atomic_int_get(&stop) > 2)
 		exit(1);
 }
+
+/* Handled connections */
+static GHashTable *connections = NULL;
+static imquic_mutex mutex = IMQUIC_MUTEX_INITIALIZER;
 
 /* RTP header */
 typedef struct imquic_rtp_header {
@@ -77,24 +81,23 @@ static gboolean imquic_is_rtp(uint8_t *buf, guint len) {
 	return ((header->type < 64) || (header->type >= 96));
 }
 
-/* Our connection */
-static imquic_connection *roq_conn = NULL;
-
 /* Callbacks */
 static void imquic_demo_new_connection(imquic_connection *conn, void *user_data) {
 	/* Got new connection */
 	imquic_connection_ref(conn);
+	imquic_mutex_lock(&mutex);
+	g_hash_table_insert(connections, conn, conn);
+	imquic_mutex_unlock(&mutex);
 	IMQUIC_LOG(IMQUIC_LOG_INFO, "[%s] New connection\n", imquic_get_connection_name(conn));
 	IMQUIC_LOG(IMQUIC_LOG_INFO, "[%s]   -- %s (%s)\n", imquic_get_connection_name(conn),
 		imquic_is_connection_webtransport(conn) ? "WebTransport" : "Raw QUIC",
 		imquic_is_connection_webtransport(conn) ? imquic_get_connection_wt_protocol(conn) : imquic_get_connection_alpn(conn));
-	roq_conn = conn;
 }
 
 static void imquic_demo_rtp_incoming(imquic_connection *conn, imquic_roq_multiplexing multiplexing,
 		uint64_t flow_id, uint8_t *bytes, size_t blen) {
-	/* If this is called, it means the server we're sending RTP packets to
-	 * sent us something back (e.g., the imquic RoQ server in echo mode) */
+	/* If this is called, it means the receiver we're sending RTP packets to
+	 * sent us something back (e.g., the imquic RoQ receiver in echo mode) */
 	if(!imquic_is_rtp(bytes, blen)) {
 		IMQUIC_LOG(IMQUIC_LOG_WARN, "[%s]  -- [flow=%"SCNu64"][%zu] Not an RTP packet\n",
 			imquic_get_connection_name(conn), flow_id, blen);
@@ -111,17 +114,23 @@ static void imquic_demo_rtp_incoming(imquic_connection *conn, imquic_roq_multipl
 static void imquic_demo_connection_failed(void *user_data) {
 	/* Connection failed */
 	IMQUIC_LOG(IMQUIC_LOG_INFO, "Connection failed\n");
-	/* Stop here */
-	g_atomic_int_inc(&stop);
+	if(options.client) {
+		/* Stop here */
+		g_atomic_int_inc(&stop);
+	}
 }
 
 static void imquic_demo_connection_gone(imquic_connection *conn, uint64_t error_code, const char *reason) {
 	/* Connection was closed */
 	IMQUIC_LOG(IMQUIC_LOG_INFO, "[%s] Connection gone\n", imquic_get_connection_name(conn));
-	if(conn == roq_conn)
+	imquic_mutex_lock(&mutex);
+	if(g_hash_table_remove(connections, conn))
 		imquic_connection_unref(conn);
-	/* Stop here */
-	g_atomic_int_inc(&stop);
+	imquic_mutex_unlock(&mutex);
+	if(options.client) {
+		/* Stop here */
+		g_atomic_int_inc(&stop);
+	}
 }
 
 int main(int argc, char *argv[]) {
@@ -154,8 +163,14 @@ int main(int argc, char *argv[]) {
 		imquic_set_refcount_debugging(TRUE);
 
 	int ret = 0, audio_fd = -1, video_fd = -1;
-	if(options.remote_host == NULL || options.remote_port == 0) {
-		IMQUIC_LOG(IMQUIC_LOG_FATAL, "Invalid QUIC server address\n");
+	IMQUIC_LOG(IMQUIC_LOG_INFO, "RoQ sender will act as a %s\n", options.client ? "client (single connection)" : "server (multiple connections)");
+	if(options.client && (options.remote_host == NULL || options.remote_port == 0)) {
+		IMQUIC_LOG(IMQUIC_LOG_FATAL, "Invalid QUIC server address (required when acting as client)\n");
+		ret = 1;
+		goto done;
+	}
+	if(!options.client && (options.cert_pem == NULL || strlen(options.cert_pem) == 0 || options.cert_key == NULL || strlen(options.cert_key) == 0)) {
+		IMQUIC_LOG(IMQUIC_LOG_FATAL, "Missing certificate/key (required when acting as server)\n");
 		ret = 1;
 		goto done;
 	}
@@ -169,8 +184,11 @@ int main(int argc, char *argv[]) {
 		ret = 1;
 		goto done;
 	}
-	if(options.ticket_file != NULL)
-		IMQUIC_LOG(IMQUIC_LOG_INFO, "Early data support enabled (ticket file '%s')\n", options.ticket_file);
+	if(options.ticket_file != NULL) {
+		IMQUIC_LOG(IMQUIC_LOG_INFO, "Early data support enabled\n");
+		if(options.client)
+			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- Ticket file '%s'\n", options.ticket_file);
+	}
 	if(options.audio_port <= 0 && options.video_port <= 0) {
 		IMQUIC_LOG(IMQUIC_LOG_FATAL, "No local audio/video RTP port specified\n");
 		ret = 1;
@@ -191,7 +209,7 @@ int main(int argc, char *argv[]) {
 		ret = 1;
 		goto done;
 	}
-	/* Since this is a RoQ server, we use a static ALPN */
+	/* We support different multiplexing modes for RoQ */
 	imquic_roq_multiplexing multiplexing;
 	const char *mode = NULL;
 	gboolean one_stream_per_packet = FALSE;
@@ -271,60 +289,82 @@ int main(int argc, char *argv[]) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "Quiet mode (won't print RTP packets)\n");
 	IMQUIC_LOG(IMQUIC_LOG_INFO, "\n");
 
-	/* Initialize the library and create a server */
+	/* Initialize the library and create a client or server endpoint */
 	if(imquic_init(options.secrets_log) < 0) {
 		ret = 1;
 		goto done;
 	}
-	imquic_client *client = imquic_create_roq_client("roq-client",
-		IMQUIC_CONFIG_INIT,
-		IMQUIC_CONFIG_TLS_CERT, options.cert_pem,
-		IMQUIC_CONFIG_TLS_KEY, options.cert_key,
-		IMQUIC_CONFIG_TLS_NO_VERIFY, TRUE,
-		IMQUIC_CONFIG_LOCAL_BIND, options.ip,
-		IMQUIC_CONFIG_LOCAL_PORT, options.port,
-		IMQUIC_CONFIG_REMOTE_HOST, options.remote_host,
-		IMQUIC_CONFIG_REMOTE_PORT, options.remote_port,
-		IMQUIC_CONFIG_SNI, options.sni,
-		IMQUIC_CONFIG_RAW_QUIC, options.raw_quic,
-		IMQUIC_CONFIG_WEBTRANSPORT, options.webtransport,
-		IMQUIC_CONFIG_EARLY_DATA, (options.ticket_file != NULL),
-		IMQUIC_CONFIG_TICKET_FILE, options.ticket_file,
-		IMQUIC_CONFIG_HTTP3_PATH, options.path,
-		IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
-		IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
-		IMQUIC_CONFIG_QLOG_HTTP3, qlog_http3,
-		IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
-		IMQUIC_CONFIG_QLOG_ROQ_PACKETS, options.qlog_roq_packets,
-		IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
-		IMQUIC_CONFIG_DONE, NULL);
-	if(client == NULL) {
+	imquic_endpoint *endpoint = NULL;
+	if(options.client) {
+		endpoint = imquic_create_roq_client("roq-sender-client",
+			IMQUIC_CONFIG_INIT,
+			IMQUIC_CONFIG_TLS_CERT, options.cert_pem,
+			IMQUIC_CONFIG_TLS_KEY, options.cert_key,
+			IMQUIC_CONFIG_TLS_NO_VERIFY, TRUE,
+			IMQUIC_CONFIG_LOCAL_BIND, options.ip,
+			IMQUIC_CONFIG_LOCAL_PORT, options.port,
+			IMQUIC_CONFIG_REMOTE_HOST, options.remote_host,
+			IMQUIC_CONFIG_REMOTE_PORT, options.remote_port,
+			IMQUIC_CONFIG_SNI, options.sni,
+			IMQUIC_CONFIG_RAW_QUIC, options.raw_quic,
+			IMQUIC_CONFIG_WEBTRANSPORT, options.webtransport,
+			IMQUIC_CONFIG_EARLY_DATA, (options.ticket_file != NULL),
+			IMQUIC_CONFIG_TICKET_FILE, options.ticket_file,
+			IMQUIC_CONFIG_HTTP3_PATH, options.path,
+			IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
+			IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
+			IMQUIC_CONFIG_QLOG_HTTP3, qlog_http3,
+			IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
+			IMQUIC_CONFIG_QLOG_ROQ_PACKETS, options.qlog_roq_packets,
+			IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
+			IMQUIC_CONFIG_DONE, NULL);
+	} else {
+		endpoint = imquic_create_roq_server("roq-sender-server",
+			IMQUIC_CONFIG_INIT,
+			IMQUIC_CONFIG_TLS_CERT, options.cert_pem,
+			IMQUIC_CONFIG_TLS_KEY, options.cert_key,
+			IMQUIC_CONFIG_TLS_NO_VERIFY, TRUE,
+			IMQUIC_CONFIG_LOCAL_BIND, options.ip,
+			IMQUIC_CONFIG_LOCAL_PORT, options.port,
+			IMQUIC_CONFIG_RAW_QUIC, options.raw_quic,
+			IMQUIC_CONFIG_WEBTRANSPORT, options.webtransport,
+			IMQUIC_CONFIG_QLOG_PATH, options.qlog_path,
+			IMQUIC_CONFIG_QLOG_QUIC, qlog_quic,
+			IMQUIC_CONFIG_QLOG_HTTP3, qlog_http3,
+			IMQUIC_CONFIG_QLOG_ROQ, qlog_roq,
+			IMQUIC_CONFIG_QLOG_ROQ_PACKETS, options.qlog_roq_packets,
+			IMQUIC_CONFIG_QLOG_SEQUENTIAL, options.qlog_sequential,
+			IMQUIC_CONFIG_EARLY_DATA, (options.ticket_file != NULL),
+			IMQUIC_CONFIG_DONE, NULL);
+	}
+	if(endpoint == NULL) {
 		ret = 1;
 		goto done;
 	}
 	if(options.raw_quic) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "ALPN(s):\n");
 		int i = 0;
-		const char **alpns = imquic_get_endpoint_alpns(client);
+		const char **alpns = imquic_get_endpoint_alpns(endpoint);
 		while(alpns[i] != NULL) {
 			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- %s\n", alpns[i]);
 			i++;
 		}
 	}
-	if(options.webtransport && imquic_get_endpoint_wt_protocols(client) != NULL) {
+	if(options.webtransport && imquic_get_endpoint_wt_protocols(endpoint) != NULL) {
 		IMQUIC_LOG(IMQUIC_LOG_INFO, "WebTransport Protocol(s):\n");
 		int i = 0;
-		const char **wt_protocols = imquic_get_endpoint_wt_protocols(client);
+		const char **wt_protocols = imquic_get_endpoint_wt_protocols(endpoint);
 		while(wt_protocols[i] != NULL) {
 			IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- %s\n", wt_protocols[i]);
 			i++;
 		}
 	}
-	imquic_set_new_roq_connection_cb(client, imquic_demo_new_connection);
-	imquic_set_rtp_incoming_cb(client, imquic_demo_rtp_incoming);
-	imquic_set_connection_failed_cb(client, imquic_demo_connection_failed);
-	imquic_set_roq_connection_gone_cb(client, imquic_demo_connection_gone);
-	imquic_start_endpoint(client);
+	imquic_set_new_roq_connection_cb(endpoint, imquic_demo_new_connection);
+	imquic_set_rtp_incoming_cb(endpoint, imquic_demo_rtp_incoming);
+	imquic_set_connection_failed_cb(endpoint, imquic_demo_connection_failed);
+	imquic_set_roq_connection_gone_cb(endpoint, imquic_demo_connection_gone);
+	connections = g_hash_table_new(NULL, NULL);
+	imquic_start_endpoint(endpoint);
 
 	/* Wait for incoming RTP packets */
 	socklen_t addrlen;
@@ -338,8 +378,9 @@ int main(int argc, char *argv[]) {
 	/* Loop */
 	while(!g_atomic_int_get(&stop)) {
 		now = g_get_monotonic_time();
-		if(now - before >= 5*G_USEC_PER_SEC) {
-			IMQUIC_LOG(IMQUIC_LOG_WARN, "5 seconds with no RTP traffic, shutting down...\n");
+		if(options.timeout > 0 && (now - before >= options.timeout*G_USEC_PER_SEC)) {
+			IMQUIC_LOG(IMQUIC_LOG_WARN, "%d seconds with no RTP traffic, shutting down...\n",
+				options.timeout);
 			break;
 		}
 		num = 0;
@@ -390,24 +431,34 @@ int main(int argc, char *argv[]) {
 					continue;
 				}
 				before = g_get_monotonic_time();
-				if(roq_conn != NULL) {
-					/* Send the RTP packet using the specified multiplexing mode */
-					flow_id = (fds[i].fd == audio_fd ? options.audio_flow : options.video_flow);
+				/* Pick the right flow ID */
+				flow_id = (fds[i].fd == audio_fd ? options.audio_flow : options.video_flow);
+				/* Send the RTP packet on all connections using the specified multiplexing mode */
+				GHashTableIter iter;
+				gpointer value;
+				imquic_mutex_lock(&mutex);
+				g_hash_table_iter_init(&iter, connections);
+				while(g_hash_table_iter_next(&iter, NULL, &value)) {
+					imquic_connection *roq_conn = (imquic_connection *)value;
 					sent = imquic_roq_send_rtp(roq_conn, multiplexing, flow_id, buffer, bytes, one_stream_per_packet);
 					if(sent == 0) {
-						IMQUIC_LOG(IMQUIC_LOG_WARN, "Couldn't send RTP packet...\n");
+						IMQUIC_LOG(IMQUIC_LOG_WARN, "[%s] Couldn't send RTP packet...\n",
+							imquic_get_connection_name(roq_conn));
 					} else if(!options.quiet) {
 						imquic_rtp_header *rtp = (imquic_rtp_header *)buffer;
-						IMQUIC_LOG(IMQUIC_LOG_INFO, "  -- [%s][flow=%"SCNu64"][%d] ssrc=%"SCNu32", pt=%"SCNu16", seq=%"SCNu16", ts=%"SCNu32"\n",
-							mode, flow_id, bytes, ntohl(rtp->ssrc), rtp->type, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
+						IMQUIC_LOG(IMQUIC_LOG_INFO, "[%s]  -- [%s][flow=%"SCNu64"][%d] ssrc=%"SCNu32", pt=%"SCNu16", seq=%"SCNu16", ts=%"SCNu32"\n",
+							imquic_get_connection_name(roq_conn),
+							mode, flow_id, bytes,
+							ntohl(rtp->ssrc), rtp->type, ntohs(rtp->seq_number), ntohl(rtp->timestamp));
 					}
 				}
+				imquic_mutex_unlock(&mutex);
 			}
 		}
 	}
 
 	/* We're done */
-	imquic_shutdown_endpoint(client);
+	imquic_shutdown_endpoint(endpoint);
 
 done:
 	if(audio_fd > -1)
@@ -415,6 +466,8 @@ done:
 	if(video_fd > -1)
 		close(video_fd);
 	imquic_deinit();
+	if(connections != NULL)
+		g_hash_table_unref(connections);
 	if(ret == 1)
 		demo_options_show_usage();
 	demo_options_destroy();

--- a/src/imquic-roq.c
+++ b/src/imquic-roq.c
@@ -102,7 +102,7 @@ imquic_server *imquic_create_roq_server(const char *name, ...) {
 	va_end(args);
 	/* Check if we need raw RoQ and/or RoQ over WebTransport */
 	config.alpn = config.raw_quic ? IMQUIC_ROQ_ALPN : NULL;
-	config.wt_protocols = config.webtransport ? IMQUIC_ROQ_ALPN : NULL;
+	config.wt_protocols = NULL;
 	/* Create the server */
 	imquic_server *server = imquic_network_endpoint_create(&config);
 	if(server == NULL)
@@ -201,7 +201,7 @@ imquic_client *imquic_create_roq_client(const char *name, ...) {
 	va_end(args);
 	/* Check if we need raw RoQ and/or RoQ over WebTransport */
 	config.alpn = config.raw_quic ? IMQUIC_ROQ_ALPN : NULL;
-	config.wt_protocols = config.webtransport ? IMQUIC_ROQ_ALPN : NULL;
+	config.wt_protocols = NULL;
 	/* Create the client */
 	imquic_client *client = imquic_network_endpoint_create(&config);
 	if(client == NULL)


### PR DESCRIPTION
The existing RoQ client/server demos made the hardcoded assumption that a client would always send packets and a server would always receive them. To make this more flexible for further demos along the way, this PR breaks this assumption, and turns the RoQ client demo into a RoQ sender demo, while the RoQ server becomes a RoQ receiver: both demos can now act as client or server, meaning this now decouples the RoQ role from the QUIC role.