### PR TITLE
Add mechanism for adding payload prefix (for LOC private objects)

### DIFF
--- a/examples/moq-loc-recv.c
+++ b/examples/moq-loc-recv.c
@@ -286,16 +286,25 @@ static void imquic_demo_process_video_buffer(void) {
 			if(videodec_ctx != NULL)
 				imquic_demo_destroy_video_decoder();
 		}
+		/* Check if there are private properties too */
+		uint8_t length = 0;
+		size_t prop_len = imquic_read_moqint(moq_version, object->payload, object->payload_len, &length);
+		if(length == 0 || length > object->payload_len) {
+			IMQUIC_LOG(IMQUIC_LOG_WARN, "Broken private properties yet, ignoring object\n");
+			return;
+		}
+		size_t skip = length + prop_len;
+		/* Process the video frame */
 		gboolean keyframe = (loc_extradata != NULL);
 		if(!keyframe) {
 			if(codec == DEMO_H264_ANNEXB)
-				keyframe = imquic_demo_h264_is_keyframe(object->payload, object->payload_len);
+				keyframe = imquic_demo_h264_is_keyframe(object->payload + skip, object->payload_len - skip);
 			else if(codec == DEMO_VP8)
-				keyframe = imquic_demo_vp8_is_keyframe(object->payload, object->payload_len);
+				keyframe = imquic_demo_vp8_is_keyframe(object->payload + skip, object->payload_len - skip);
 			else if(codec == DEMO_VP9)
-				keyframe = imquic_demo_vp9_is_keyframe(object->payload, object->payload_len);
+				keyframe = imquic_demo_vp9_is_keyframe(object->payload + skip, object->payload_len - skip);
 			if(codec == DEMO_AV1)
-				keyframe = imquic_demo_av1_is_keyframe(object->payload, object->payload_len);
+				keyframe = imquic_demo_av1_is_keyframe(object->payload + skip, object->payload_len - skip);
 		}
 		if(videodec_ctx == NULL && (keyframe || codec == DEMO_AV1)) {
 			if(imquic_demo_create_video_decoder(loc_extradata ? loc_extradata->buffer : NULL,
@@ -306,7 +315,7 @@ static void imquic_demo_process_video_buffer(void) {
 			}
 		}
 		gboolean render = (temp->next == NULL);
-		imquic_demo_decode_video(object->payload, object->payload_len, keyframe, render);
+		imquic_demo_decode_video(object->payload + skip, object->payload_len - skip, keyframe, render);
 		temp = temp->next;
 	}
 	g_list_free_full(video_buffer, (GDestroyNotify)imquic_moq_object_cleanup);
@@ -336,7 +345,6 @@ static void imquic_demo_ready(imquic_connection *conn) {
 		imquic_moq_version_str(moq_version));
 	IMQUIC_LOG(IMQUIC_LOG_INFO, "[%s]   -- %s\n", imquic_get_connection_name(conn),
 		peer ? peer : "unknown implementation");
-	moq_version = imquic_moq_get_version(conn);
 	/* Let's subscribe to the provided namespace/track(s) */
 	imquic_moq_request_parameters params;
 	imquic_moq_request_parameters_init_defaults(&params);
@@ -421,7 +429,7 @@ static void imquic_demo_subscribe_accepted(imquic_connection *conn, uint64_t req
 		}
 	}
 	if(track_properties != NULL)
-		imquic_moq_properties_print(imquic_moq_get_version(conn), IMQUIC_LOG_VERB, track_properties);
+		imquic_moq_properties_print(moq_version, IMQUIC_LOG_VERB, track_properties);
 }
 
 static void imquic_demo_subscribe_error(imquic_connection *conn, uint64_t request_id, imquic_moq_request_error_code error_code,
@@ -596,7 +604,7 @@ static void imquic_demo_incoming_object(imquic_connection *conn, imquic_moq_obje
 	}
 	/* If we got here, it's an audio or video object */
 	if(object->properties != NULL)
-		imquic_moq_properties_print(imquic_moq_get_version(conn), IMQUIC_LOG_VERB, object->properties);
+		imquic_moq_properties_print(moq_version, IMQUIC_LOG_VERB, object->properties);
 	/* FIXME Assuming LOC from https://github.com/facebookexperimental/moq-encoder-player/
 	 * which uses the MoQ-MI draft: https://datatracker.ietf.org/doc/html/draft-cenzano-moq-media-interop */
 	if(object->properties == NULL) {
@@ -654,6 +662,22 @@ static void imquic_demo_incoming_object(imquic_connection *conn, imquic_moq_obje
 			IMQUIC_LOG(IMQUIC_LOG_LOCPROP, "  -- -- SPS number:    %"SCNu8"\n", avcc_data[5] & 0x1F);
 		}
 		IMQUIC_LOG(IMQUIC_LOG_LOCPROP, "  -- Payload: %zu bytes\n", object->payload_len);
+		/* Check if there are private properties too */
+		uint8_t length = 0;
+		size_t prop_len = imquic_read_moqint(moq_version, object->payload, object->payload_len, &length);
+		if(length == 0 || length > object->payload_len) {
+			IMQUIC_LOG(IMQUIC_LOG_WARN, "Broken private properties yet, ignoring object\n");
+			return;
+		}
+		size_t skip = length;
+		GList *pvt_properties = NULL;
+		if(prop_len > 0) {
+			pvt_properties = imquic_moq_parse_properties(moq_version, object->payload + skip, prop_len);
+			IMQUIC_LOG(IMQUIC_LOG_LOCPROP, "  -- %d private properties\n", g_list_length(pvt_properties));
+			if(pvt_properties != NULL)
+				imquic_moq_properties_print(moq_version, IMQUIC_LOG_VERB, pvt_properties);
+		}
+		skip += prop_len;
 		/* Decode the frame */
 		if(audio_tn != NULL && object->track_alias == audio_track_alias && object->delivery != IMQUIC_MOQ_USE_FETCH) {
 			/* Decode audio, and create a decoder if we don't have one yet */
@@ -662,7 +686,7 @@ static void imquic_demo_incoming_object(imquic_connection *conn, imquic_moq_obje
 				g_atomic_int_inc(&stop);
 				return;
 			}
-			imquic_demo_decode_audio(object->payload, object->payload_len);
+			imquic_demo_decode_audio(object->payload + skip, object->payload_len - skip);
 		} else if(video_tn != NULL &&
 				((object->track_alias == video_track_alias && object->delivery != IMQUIC_MOQ_USE_FETCH) ||
 				(object->request_id == video_fetch_request_id && object->delivery == IMQUIC_MOQ_USE_FETCH))) {
@@ -685,13 +709,13 @@ static void imquic_demo_incoming_object(imquic_connection *conn, imquic_moq_obje
 			gboolean keyframe = (loc_extradata != NULL);
 			if(!keyframe) {
 				if(codec == DEMO_H264_ANNEXB)
-					keyframe = imquic_demo_h264_is_keyframe(object->payload, object->payload_len);
+					keyframe = imquic_demo_h264_is_keyframe(object->payload + skip, object->payload_len - skip);
 				else if(codec == DEMO_VP8)
-					keyframe = imquic_demo_vp8_is_keyframe(object->payload, object->payload_len);
+					keyframe = imquic_demo_vp8_is_keyframe(object->payload + skip, object->payload_len - skip);
 				else if(codec == DEMO_VP9)
-					keyframe = imquic_demo_vp9_is_keyframe(object->payload, object->payload_len);
+					keyframe = imquic_demo_vp9_is_keyframe(object->payload + skip, object->payload_len - skip);
 				if(codec == DEMO_AV1)
-					keyframe = imquic_demo_av1_is_keyframe(object->payload, object->payload_len);
+					keyframe = imquic_demo_av1_is_keyframe(object->payload + skip, object->payload_len - skip);
 			}
 			if(videodec_ctx == NULL && (keyframe || codec == DEMO_AV1)) {
 				if(imquic_demo_create_video_decoder(loc_extradata ? loc_extradata->buffer : NULL,
@@ -702,7 +726,7 @@ static void imquic_demo_incoming_object(imquic_connection *conn, imquic_moq_obje
 				}
 			}
 			gboolean render = (object->delivery != IMQUIC_MOQ_USE_FETCH);
-			imquic_demo_decode_video(object->payload, object->payload_len, keyframe, render);
+			imquic_demo_decode_video(object->payload + skip, object->payload_len - skip, keyframe, render);
 		}
 	}
 	if(object->end_of_stream) {

--- a/examples/moq-loc-send.c
+++ b/examples/moq-loc-send.c
@@ -363,6 +363,9 @@ static void *imquic_demo_audio_thread(void *user_data) {
 	uint8_t audio[1920], outgoing[500];
 	size_t outlen = sizeof(outgoing);
 	uint32_t avail = 0, want = samples*2, got = 0, cached = 0;
+	/* FIXME We currently don't support LOC private properties, so
+	 * we always send a 0x00 as a payload prefix to signal it's empty */
+	uint8_t loc_pvt_props = 0;
 
 	while(!stop) {
 		/* FIXME Loop */
@@ -421,6 +424,8 @@ static void *imquic_demo_audio_thread(void *user_data) {
 				.group_id = audio_group_id++,
 				.subgroup_id = 0,	/* FIXME */
 				.object_id = audio_object_id,
+				.payload_prefix = &loc_pvt_props,
+				.payload_prefix_len = 1,
 				.payload = outgoing,
 				.payload_len = length,
 				.properties = props,
@@ -525,6 +530,9 @@ static void *imquic_demo_video_enc_thread(void *user_data) {
 
 	AVPacket packet = { 0 };
 	int64_t now = 0, before = 0, wait = G_USEC_PER_SEC/options.video_framerate;
+	/* FIXME We currently don't support LOC private properties, so
+	 * we always send a 0x00 as a payload prefix to signal it's empty */
+	uint8_t loc_pvt_props = 0;
 
 	while(!stop) {
 		/* FIXME Loop */
@@ -659,6 +667,8 @@ static void *imquic_demo_video_enc_thread(void *user_data) {
 			.group_id = video_group_id,
 			.subgroup_id = 0,	/* FIXME */
 			.object_id = video_object_id,
+			.payload_prefix = &loc_pvt_props,
+			.payload_prefix_len = 1,
 			.payload = packet.data,
 			.payload_len = packet.size,
 			.properties = props,

--- a/examples/moq-utils.c
+++ b/examples/moq-utils.c
@@ -18,6 +18,12 @@ imquic_moq_object *imquic_moq_object_duplicate(imquic_moq_object *object) {
 		return NULL;
 	imquic_moq_object *new_obj = g_malloc(sizeof(imquic_moq_object));
 	memcpy(new_obj, object, sizeof(imquic_moq_object));
+	if(object->payload_prefix_len == 0) {
+		new_obj->payload_prefix = NULL;
+	} else {
+		new_obj->payload_prefix = g_malloc(object->payload_prefix_len);
+		memcpy(new_obj->payload_prefix, object->payload_prefix, object->payload_prefix_len);
+	}
 	if(object->payload_len == 0) {
 		new_obj->payload = NULL;
 	} else {
@@ -77,6 +83,7 @@ GList *imquic_moq_properties_duplicate(GList *properties) {
 /* Helper to destroy a duplicated object */
 void imquic_moq_object_cleanup(imquic_moq_object *object) {
 	if(object) {
+		g_free(object->payload_prefix);
 		g_free(object->payload);
 		g_list_free_full(object->properties, (GDestroyNotify)(imquic_moq_property_cleanup));
 		g_free(object);

--- a/src/imquic/moq.h
+++ b/src/imquic/moq.h
@@ -670,6 +670,21 @@ typedef enum imquic_moq_property_type {
  * @returns The type name as a string, if valid, or NULL otherwise */
 const char *imquic_moq_property_type_str(imquic_moq_version version, imquic_moq_property_type type);
 
+/*! \brief Helper mode to parse a properties buffer to a GList of imquic_moq_property
+ * \note The caller owns the list, and is responsible of freeing it and its content
+ * @param version The version of the connection
+ * @param properties The buffer containing the properties data
+ * @param plen The size of the buffer containing the properties data
+ * @returns A GList instance containing a set of imquic_moq_property, if successful, or NULL if no properties were found */
+GList *imquic_moq_parse_properties(imquic_moq_version version, uint8_t *properties, size_t plen);
+/*! \brief Helper mode to craft a properties buffer out of a GList of imquic_moq_property
+ * @param[in] version The version of the connection
+ * @param[in] properties The list of properties to serialize
+ * @param[out] bytes The buffer to write the properties data to
+ * @param[in] blen The size of the buffer to write to
+ * @returns How many bytes were written, if successful */
+size_t imquic_moq_build_properties(imquic_moq_version version, GList *properties, uint8_t *bytes, size_t blen);
+
 /*! \brief MoQ Object
  * \note This may contain info related to different MoQ versions, and so
  * should be considered a higher level abstraction that the internal
@@ -689,12 +704,23 @@ typedef struct imquic_moq_object {
 	imquic_moq_object_status object_status;
 	/*! \brief MoQ publisher priority */
 	uint8_t priority;
+	/*! \brief MoQ properties, if any */
+	GList *properties;
+	/*! \brief MoQ object payload prefix, if needed
+	 * \note At the moment, this is only needed when adding private
+	 * properties with LOC. Notice that the prefix is ALWAYS empty
+	 * when getting incoming objects from the stack, since the library
+	 * doesn't know how to process the payload, and so you'll always
+	 * only see the payload as a whole in that case, meaning it's up to
+	 * you to demux the prefix. This mechanism is only here to make
+	 * things easier when sending LOC objects without reallocating buffers */
+	uint8_t *payload_prefix;
+	/*! \brief Size of the MoQ object payload prefix */
+	size_t payload_prefix_len;
 	/*! \brief MoQ object payload */
 	uint8_t *payload;
 	/*! \brief Size of the MoQ object payload */
 	size_t payload_len;
-	/*! \brief MoQ properties, if any */
-	GList *properties;
 	/*! \brief How to send this object (or how it was received) */
 	imquic_moq_delivery delivery;
 	/*! \brief Whether the first object in the stream contains the first object in the subgroup (added in v18) */
@@ -702,6 +728,29 @@ typedef struct imquic_moq_object {
 	/*! \brief Whether this signals the end of the stream */
 	gboolean end_of_stream;
 } imquic_moq_object;
+///@}
+
+/** @name MoQ's flavour of varint (introduced in v17)
+ */
+///@{
+/*! \brief Read a variable size integer from a buffer
+ * @note You can use the return value to know how many bytes to skip in
+ * the buffer to read the next value. In case of issues in the parsing,
+ * length will have value 0.
+ * @param[in] bytes The buffer to read
+ * @param[in] blen The size of the buffer
+ * @param[out] length How many bytes the variable size integer used
+ * @returns The variable size integer, if length is higher than 0 */
+uint64_t imquic_read_moqint(imquic_moq_version version, uint8_t *bytes, size_t blen, uint8_t *length);
+/*! \brief Write a variable size integer to a buffer
+ * @note You can use the return value to know how many bytes to skip in
+ * the buffer to write the next value. In case of issues in the writing,
+ * length will have value 0.
+ * @param[in] number The number to write as a variable size integer
+ * @param[in] bytes The buffer to write to
+ * @param[in] blen The size of the buffer
+ * @returns How many bytes the variable size integer used, if successful, 0 otherwise */
+uint8_t imquic_write_moqint(imquic_moq_version version, uint64_t number, uint8_t *bytes, size_t blen);
 ///@}
 
 /** @name MoQ authorization and tokens

--- a/src/internal/moq.h
+++ b/src/internal/moq.h
@@ -286,21 +286,6 @@ typedef struct imquic_moq_setup_options {
 	gboolean unknown;
 } imquic_moq_setup_options;
 
-/*! \brief Helper mode to parse a properties buffer to a GList of imquic_moq_property
- * \note The caller owns the list, and is responsible of freeing it and its content
- * @param version The version of the connection
- * @param properties The buffer containing the properties data
- * @param plen The size of the buffer containing the properties data
- * @returns A GList instance containing a set of imquic_moq_property, if successful, or NULL if no properties were found */
-GList *imquic_moq_parse_properties(imquic_moq_version version, uint8_t *properties, size_t plen);
-/*! \brief Helper mode to craft a properties buffer out of a GList of imquic_moq_property
- * @param[in] version The version of the connection
- * @param[in] properties The list of properties to serialize
- * @param[out] bytes The buffer to write the properties data to
- * @param[in] blen The size of the buffer to write to
- * @returns How many bytes were written, if successful */
-size_t imquic_moq_build_properties(imquic_moq_version version, GList *properties, uint8_t *bytes, size_t blen);
-
 /*! \brief MoQ FETCH types */
 typedef enum imquic_moq_fetch_type {
 	IMQUIC_MOQ_FETCH_STANDALONE = 0x01,
@@ -1088,6 +1073,8 @@ size_t imquic_moq_add_goaway(imquic_moq_context *moq, imquic_moq_stream *moq_str
  * @param object_id The object ID to put in the message
  * @param object_status The object status (only added if the payload length is 0)
  * @param priority The publisher priority to put in the message
+ * @param payload_prefix The buffer containing the payload prefix of the object, if needed
+ * @param pplen The size of the payload prefix buffer
  * @param payload The buffer containing the payload of the object
  * @param plen The size of the payload buffer
  * @param properties The buffer containing the properties, if any
@@ -1095,7 +1082,7 @@ size_t imquic_moq_add_goaway(imquic_moq_context *moq, imquic_moq_stream *moq_str
  * @returns The size of the generated message, if successful, or 0 otherwise */
 size_t imquic_moq_add_object_datagram(imquic_moq_context *moq, uint8_t *bytes, size_t blen, uint64_t request_id, uint64_t track_alias,
 	uint64_t group_id, uint64_t object_id, uint64_t object_status, uint8_t priority,
-	uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen);
+	uint8_t *payload_prefix, size_t pplen, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen);
 /*! \brief Helper to add an \c OBJECT_DATAGRAM_STATUS message to a buffer
  * @note This assumes the connection negotiated \c DATAGRAM support
  * @param moq The imquic_moq_context generating the message
@@ -1136,6 +1123,8 @@ size_t imquic_moq_add_subgroup_header(imquic_moq_context *moq, imquic_moq_stream
  * @param blen The size of the buffer
  * @param object_id The object ID
  * @param object_status The object status (only added if the payload length is 0)
+ * @param payload_prefix The buffer containing the payload prefix of the object, if needed
+ * @param pplen The size of the payload prefix buffer
  * @param payload The buffer containing the payload of the object
  * @param plen The size of the payload buffer
  * @param properties The buffer containing the properties, if any
@@ -1143,7 +1132,7 @@ size_t imquic_moq_add_subgroup_header(imquic_moq_context *moq, imquic_moq_stream
  * @returns The size of the generated object, if successful, or 0 otherwise */
 size_t imquic_moq_add_subgroup_header_object(imquic_moq_context *moq, imquic_moq_stream *moq_stream,
 	uint8_t *bytes, size_t blen, uint64_t object_id, uint64_t object_status,
-	uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen);
+	uint8_t *payload_prefix, size_t pplen, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen);
 /*! \brief Helper to add a \c FETCH_HEADER message to a buffer
  * @note This will create a new \c STREAM and send the header: after
  * that, imquic_moq_add_fetch_header_object is used to send
@@ -1165,6 +1154,8 @@ size_t imquic_moq_add_fetch_header(imquic_moq_context *moq, uint8_t *bytes, size
  * @param object_id The object ID
  * @param priority The publisher priority to put in the message
  * @param object_status The object status (only added if the payload length is 0)
+ * @param payload_prefix The buffer containing the payload prefix of the object, if needed
+ * @param pplen The size of the payload prefix buffer
  * @param payload The buffer containing the payload of the object
  * @param plen The size of the payload buffer
  * @param properties The buffer containing the properties, if any
@@ -1172,7 +1163,7 @@ size_t imquic_moq_add_fetch_header(imquic_moq_context *moq, uint8_t *bytes, size
  * @returns The size of the generated object, if successful, or 0 otherwise */
 size_t imquic_moq_add_fetch_header_object(imquic_moq_context *moq, uint8_t *bytes, size_t blen,
 	uint64_t flags, uint64_t group_id, uint64_t subgroup_id, uint64_t object_id, uint8_t priority,
-	uint64_t object_status, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen);
+	uint64_t object_status, uint8_t *payload_prefix, size_t pplen, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen);
 /*! \brief Helper to add padding data to a buffer, formatted as expected
  * for \c PADDING_STREAM or \c PADDING_DATAGRAM
  * @param moq The imquic_moq_context generating the object

--- a/src/moq.c
+++ b/src/moq.c
@@ -49,10 +49,6 @@ static void imquic_moq_pending_stream_destroy(imquic_moq_pending_stream *stream)
 }
 static GHashTable *moq_pending_streams = NULL;
 
-/* MoQ's flavour of varint (introduced in v17) */
-static uint64_t imquic_read_moqint(imquic_moq_version version, uint8_t *bytes, size_t blen, uint8_t *length);
-static uint8_t imquic_write_moqint(imquic_moq_version version, uint64_t number, uint8_t *bytes, size_t blen);
-
 /* Helpers to check and generate GREASE values */
 #define IMQUIC_MOQ_GREASE_BASE	0x7f
 #define IMQUIC_MOQ_GREASE_SUM	0x9D
@@ -5262,7 +5258,7 @@ size_t imquic_moq_add_goaway(imquic_moq_context *moq, imquic_moq_stream *moq_str
 
 size_t imquic_moq_add_object_datagram(imquic_moq_context *moq, uint8_t *bytes, size_t blen, uint64_t request_id, uint64_t track_alias,
 		uint64_t group_id, uint64_t object_id, uint64_t object_status, uint8_t priority,
-		uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen) {
+		uint8_t *payload_prefix, size_t pplen, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen) {
 	if(bytes == NULL || blen < 1) {
 		IMQUIC_LOG(IMQUIC_LOG_ERR, "[%s][MoQ] Can't add MoQ %s: invalid arguments\n",
 			imquic_get_connection_name(moq->conn), imquic_moq_datagram_message_type_str(IMQUIC_MOQ_OBJECT_DATAGRAM, moq->version));
@@ -5289,6 +5285,10 @@ size_t imquic_moq_add_object_datagram(imquic_moq_context *moq, uint8_t *bytes, s
 	}
 	if(has_prop)
 		offset += imquic_moq_add_properties(moq, &bytes[offset], blen-offset, properties, prlen, TRUE);
+	if(payload_prefix != NULL && pplen > 0) {
+		memcpy(&bytes[offset], payload_prefix, pplen);
+		offset += pplen;
+	}
 	if(payload != NULL && plen > 0) {
 		memcpy(&bytes[offset], payload, plen);
 		offset += plen;
@@ -5352,7 +5352,7 @@ size_t imquic_moq_add_subgroup_header(imquic_moq_context *moq, imquic_moq_stream
 
 size_t imquic_moq_add_subgroup_header_object(imquic_moq_context *moq, imquic_moq_stream *moq_stream,
 		uint8_t *bytes, size_t blen, uint64_t object_id, uint64_t object_status,
-		uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen) {
+		uint8_t *payload_prefix, size_t pplen, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen) {
 	if(bytes == NULL || blen < 1) {
 		IMQUIC_LOG(IMQUIC_LOG_ERR, "[%s][MoQ] Can't add MoQ %s object: invalid arguments\n",
 			imquic_get_connection_name(moq->conn), imquic_moq_data_message_type_str(IMQUIC_MOQ_SUBGROUP_HEADER, moq->version));
@@ -5366,11 +5366,17 @@ size_t imquic_moq_add_subgroup_header_object(imquic_moq_context *moq, imquic_moq
 	imquic_moq_data_message_type_to_subgroup_header(moq->version, moq_stream->type, NULL, NULL, &has_prop, NULL, NULL, NULL, NULL);
 	if(has_prop)
 		offset += imquic_moq_add_properties(moq, &bytes[offset], blen-offset, properties, prlen, TRUE);
+	if(payload_prefix == NULL)
+		pplen = 0;
 	if(payload == NULL)
 		plen = 0;
-	offset += imquic_write_moqint(moq->version, plen, &bytes[offset], blen-offset);
-	if(plen == 0)
+	offset += imquic_write_moqint(moq->version, pplen + plen, &bytes[offset], blen-offset);
+	if(pplen == 0 && plen == 0)
 		offset += imquic_write_moqint(moq->version, object_status, &bytes[offset], blen-offset);
+	if(pplen > 0) {
+		memcpy(&bytes[offset], payload_prefix, pplen);
+		offset += pplen;
+	}
 	if(plen > 0) {
 		memcpy(&bytes[offset], payload, plen);
 		offset += plen;
@@ -5391,7 +5397,7 @@ size_t imquic_moq_add_fetch_header(imquic_moq_context *moq, uint8_t *bytes, size
 
 size_t imquic_moq_add_fetch_header_object(imquic_moq_context *moq, uint8_t *bytes, size_t blen,
 		uint64_t flags, uint64_t group_id, uint64_t subgroup_id, uint64_t object_id, uint8_t priority,
-		uint64_t object_status, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen) {
+		uint64_t object_status, uint8_t *payload_prefix, size_t pplen, uint8_t *payload, size_t plen, uint8_t *properties, size_t prlen) {
 	if(bytes == NULL || blen < 1) {
 		IMQUIC_LOG(IMQUIC_LOG_ERR, "[%s][MoQ] Can't add MoQ %s object: invalid arguments\n",
 			imquic_get_connection_name(moq->conn), imquic_moq_data_message_type_str(IMQUIC_MOQ_FETCH_HEADER, moq->version));
@@ -5415,11 +5421,17 @@ size_t imquic_moq_add_fetch_header_object(imquic_moq_context *moq, uint8_t *byte
 	}
 	if(has_prop)
 		offset += imquic_moq_add_properties(moq, &bytes[offset], blen-offset, properties, prlen, TRUE);
+	if(payload_prefix == NULL)
+		pplen = 0;
 	if(payload == NULL)
 		plen = 0;
-	offset += imquic_write_moqint(moq->version, plen, &bytes[offset], blen-offset);
-	if(plen == 0)
+	offset += imquic_write_moqint(moq->version, pplen + plen, &bytes[offset], blen-offset);
+	if(plen == 0 && pplen == 0)
 		offset += imquic_write_moqint(moq->version, object_status, &bytes[offset], blen-offset);
+	if(pplen > 0) {
+		memcpy(&bytes[offset], payload_prefix, pplen);
+		offset += pplen;
+	}
 	if(plen > 0) {
 		memcpy(&bytes[offset], payload, plen);
 		offset += plen;
@@ -7889,8 +7901,8 @@ int imquic_moq_send_object(imquic_connection *conn, imquic_moq_object *object) {
 		if(has_payload) {
 			size_t dg_len = imquic_moq_add_object_datagram(moq, buffer, bufsize,
 				object->request_id, object->track_alias, object->group_id, object->object_id, object->object_status,
-				object->priority, object->payload, object->payload_len,
-				properties, properties_len);
+				object->priority, object->payload_prefix, object->payload_prefix_len,
+				object->payload, object->payload_len, properties, properties_len);
 			if(conn->qlog != NULL && conn->qlog->moq)
 				imquic_moq_qlog_object_datagram_created(conn->qlog, object);
 			imquic_connection_send_on_datagram(conn, buffer, dg_len);
@@ -7938,6 +7950,9 @@ int imquic_moq_send_object(imquic_connection *conn, imquic_moq_object *object) {
 				TRUE,	/* End-of-Group is set */
 				TRUE,	/* We'll add the Publisher Priority property */
 				object->first_of_subgroup);	/* We take this from the object provided by the user */
+			moq_stream->track_alias = object->track_alias;
+			moq_stream->group_id = object->group_id;
+			moq_stream->subgroup_id = object->subgroup_id;
 			moq_stream->priority = 128;	/* FIXME */
 			imquic_connection_new_stream_id(conn, FALSE, &moq_stream->stream_id);
 			g_hash_table_insert(moq_sub->streams_by_subgroup, imquic_dup_uint64(lookup_id), moq_stream);
@@ -7973,7 +7988,9 @@ int imquic_moq_send_object(imquic_connection *conn, imquic_moq_object *object) {
 			moq_stream->got_objects = TRUE;
 			moq_stream->last_object_id = object->object_id;
 			shgo_len = imquic_moq_add_subgroup_header_object(moq, moq_stream, buffer, bufsize,
-				object_id, object->object_status, object->payload, object->payload_len,
+				object_id, object->object_status,
+				object->payload_prefix, object->payload_prefix_len,
+				object->payload, object->payload_len,
 				properties, properties_len);
 			if(conn->qlog != NULL && conn->qlog->moq)
 				imquic_moq_qlog_subgroup_object_created(conn->qlog, moq_stream->stream_id, object);
@@ -8068,8 +8085,9 @@ int imquic_moq_send_object(imquic_connection *conn, imquic_moq_object *object) {
 			moq_stream->last_group_id = object->group_id;
 			moq_stream->last_object_id = object->object_id;
 			shto_len = imquic_moq_add_fetch_header_object(moq, buffer, bufsize, flags,
-				group_id, object->subgroup_id, object_id, object->priority,
-				object->object_status, object->payload, object->payload_len,
+				group_id, object->subgroup_id, object_id, object->priority, object->object_status,
+				object->payload_prefix, object->payload_prefix_len,
+				object->payload, object->payload_len,
 				properties, properties_len);
 			if(conn->qlog != NULL && conn->qlog->moq)
 				imquic_moq_qlog_fetch_object_created(conn->qlog, moq_stream->stream_id, object);
@@ -8126,7 +8144,7 @@ int imquic_moq_send_padding(imquic_connection *conn, size_t padding, gboolean da
 }
 
 /* Reading and writing MoQ's flavour of variable size integers */
-static uint64_t imquic_read_moqint(imquic_moq_version version, uint8_t *bytes, size_t blen, uint8_t *length) {
+uint64_t imquic_read_moqint(imquic_moq_version version, uint8_t *bytes, size_t blen, uint8_t *length) {
 	if(version <= IMQUIC_MOQ_VERSION_16)
 		return imquic_read_varint(bytes, blen, length);
 	if(length)
@@ -8178,7 +8196,7 @@ done:
 	return res;
 }
 
-static uint8_t imquic_write_moqint(imquic_moq_version version, uint64_t number, uint8_t *bytes, size_t blen) {
+uint8_t imquic_write_moqint(imquic_moq_version version, uint64_t number, uint8_t *bytes, size_t blen) {
 	if(version <= IMQUIC_MOQ_VERSION_16)
 		return imquic_write_varint(number, bytes, blen);
 	if(blen < 1)


### PR DESCRIPTION
Only meant for making it easier when passing object to send to the stack: for incoming packets, that mechanism is not used, since the stack is unaware of how the payload is formatted.