### PR TITLE
fix: correct FETCH object parsing of subgroup flags and object status

### DIFF
--- a/src/moq.c
+++ b/src/moq.c
@@ -930,7 +930,7 @@ void imquic_moq_parse_fetch_serialization_flags(imquic_moq_version version, uint
 		gboolean *datagram, gboolean *end_ne_range, gboolean *end_uk_range, gboolean *violation) {
 	/* Make sure the provided flags are valid, or return a protocol violation */
 	if(!imquic_moq_is_fetch_serialization_flags_valid(version, flags)) {
-		if(*violation)
+		if(violation)
 			*violation = TRUE;
 		return;
 	}
@@ -944,12 +944,12 @@ void imquic_moq_parse_fetch_serialization_flags(imquic_moq_version version, uint
 	/* If we're here, we're parsing a bitmask of a single byte */
 	uint8_t flags8 = (uint8_t)flags;
 	uint8_t lsb = flags8 & 0x03;
-	if(*subgroup) {
+	if(subgroup) {
 		if(lsb == 0x00)
 			*subgroup = IMQUIC_MOQ_FETCH_SUBGROUP_ZERO;
-		if(lsb == 0x01)
+		else if(lsb == 0x01)
 			*subgroup = IMQUIC_MOQ_FETCH_SUBGROUP_PREVIOUS;
-		if(lsb == 0x02)
+		else if(lsb == 0x02)
 			*subgroup = IMQUIC_MOQ_FETCH_SUBGROUP_PLUS_ONE;
 		else
 			*subgroup = IMQUIC_MOQ_FETCH_SUBGROUP_ID;
@@ -4765,7 +4765,7 @@ int imquic_moq_parse_fetch_header_object(imquic_moq_context *moq, imquic_moq_str
 		if(length == 0 || length >= blen-offset)
 			return -1;	/* Not enough data, try again later */
 		offset += length;
-	} else {
+	} else if(subgroup_type != IMQUIC_MOQ_FETCH_SUBGROUP_ZERO) {
 		/* The subgroup ID references a previous object */
 		IMQUIC_MOQ_CHECK_ERR(!moq_stream->got_objects, error, IMQUIC_MOQ_PROTOCOL_VIOLATION, -1, "Serialization flag references non-existing previous object");
 		if(subgroup_type == IMQUIC_MOQ_FETCH_SUBGROUP_PREVIOUS)
@@ -4814,16 +4814,10 @@ int imquic_moq_parse_fetch_header_object(imquic_moq_context *moq, imquic_moq_str
 	if(length == 0 || length >= blen-offset)
 		return -1;	/* Not enough data, try again later */
 	offset += length;
+	/* A FETCH object has no Object Status field: a zero length payload is a zero
+	 * length object, and a range that is missing or unknown is conveyed with an
+	 * End of Range indicator instead. Only Subgroup objects carry the status. */
 	uint64_t object_status = 0;
-	if(p_len == 0) {
-		object_status = imquic_read_moqint(moq->version, &bytes[offset], blen-offset, &length);
-		if(length == 0 || length > blen-offset)
-			return -1;	/* Not enough data, try again later */
-		/* TODO An invalid object status should be a protocol violation error */
-		//~ IMQUIC_MOQ_CHECK_ERR(object_status > IMQUIC_MOQ_END_OF_TRACK, error, IMQUIC_MOQ_PROTOCOL_VIOLATION, 0, "Invalid object status");
-		//~ IMQUIC_MOQ_CHECK_ERR(object_status == IMQUIC_MOQ_OBJECT_DOESNT_EXIST && prop_len > 0, error, IMQUIC_MOQ_PROTOCOL_VIOLATION, 0, "Properties received in object with status 'Does Not Exist'");
-		offset += length;
-	}
 	if(p_len > blen-offset)
 		return -1;	/* Not enough data, try again later */
 	IMQUIC_LOG(IMQUIC_MOQ_LOG_HUGE, "[%s][MoQ]  -- Group ID:       %"SCNu64"\n",
@@ -5994,8 +5988,6 @@ size_t imquic_moq_add_fetch_header_object(imquic_moq_context *moq, uint8_t *byte
 	if(payload == NULL)
 		plen = 0;
 	offset += imquic_write_moqint(moq->version, pplen + plen, &bytes[offset], blen-offset);
-	if(plen == 0 && pplen == 0)
-		offset += imquic_write_moqint(moq->version, object_status, &bytes[offset], blen-offset);
 	if(pplen > 0) {
 		memcpy(&bytes[offset], payload_prefix, pplen);
 		offset += pplen;


### PR DESCRIPTION
Three defects in the FETCH object path, found while testing against another draft-18 implementation. All three are in how a FETCH object is read, so a peer that serialises it correctly is misparsed.

Subgroup serialization flags: the four branches selecting the subgroup mode are independent `if` statements, and the `else` belongs to the third alone. Modes 0x00 and 0x01 are therefore assigned and then immediately overwritten with SUBGROUP_ID, so the parser reads a Subgroup ID field that the sender never wrote and every field after it shifts by one varint. Only 0x02 and 0x03 came out right. Turning the chain into if/else if fixes it.

Subgroup ID of zero: with the chain corrected, mode 0x00 reached the branch that resolves a subgroup from the previous object, which rejects the first object on a stream as referencing a non-existing prior object. A Subgroup ID of zero is a literal, not a back-reference, so it is now excluded from that branch and the id keeps its initial value.

Object status: a FETCH object has no Object Status field. Both the parser and the serialiser treated a zero length payload as introducing one, which is the Subgroup object layout, not the Fetch one -- Figure 27 has no status field, and neither did the equivalent figure in draft-16, so this is not version specific. A missing or unknown range is conveyed with an End of Range indicator instead. Since both sides agreed, imquic interoperated with itself and only failed against other implementations.

Also corrects two `if(*ptr)` null checks that dereference the value instead of testing the pointer, one of which meant a protocol violation was only ever reported if the flag was already set.

Verified against a MOQtail relay: a FETCH of 89 cached objects previously desynchronised at the first object and delivered garbage subgroup ids, zero length payloads and broken properties; it now arrives intact. The status change was confirmed separately by serving a zero length object and observing the stream truncate at that point without the fix and complete with it.